### PR TITLE
Mini Player responsive resizing & Mini Player opens at the position it was closed

### DIFF
--- a/src/app/plugins/miniPlayerProvider.plugin.ts
+++ b/src/app/plugins/miniPlayerProvider.plugin.ts
@@ -2,7 +2,7 @@ import { AfterInit, BaseProvider } from '@/app/utils/baseProvider';
 import { IpcContext, IpcHandle } from '@/app/utils/onIpcEvent';
 import { App, BrowserWindow } from 'electron';
 
-import { createAppWindow } from '../utils/windowUtils';
+import { createAppWindow, wrapWindowHandler } from '../utils/windowUtils';
 
 @IpcContext
 export default class MiniPlayerProvider extends BaseProvider implements AfterInit {
@@ -14,7 +14,7 @@ export default class MiniPlayerProvider extends BaseProvider implements AfterIni
   }
   async AfterInit() {
   }
-  @IpcHandle("action:miniplayer.stayOnTop")
+   @IpcHandle("action:miniplayer.stayOnTop")
   private async __onPlayerTop() {
     const window = this.windowContext.views.miniPlayerWindow as any as BrowserWindow;
     const isOnTop = !window.isAlwaysOnTop();
@@ -33,28 +33,36 @@ export default class MiniPlayerProvider extends BaseProvider implements AfterIni
     let mpId: number;
     let mpWindow = this.windowContext.views
       .miniPlayerWindow as any as BrowserWindow;
-    if (!mpWindow || mpWindow.isDestroyed()) {
+   if (!mpWindow || mpWindow.isDestroyed()) {
       mpWindow = await createAppWindow({
-        // parent: this.windowContext.main, 
         path: "/miniplayer",
         minWidth: 340,
         minHeight: 340,
         height: 340,
         width: 540
       });
+      
+      const { state, saveState } = await wrapWindowHandler(mpWindow, 'miniPlayer', { width: 540, height: 340 });
+            
+      if (state) {
+        mpWindow.setBounds(state);
+      } else {
+        mpWindow.setBounds({ width: 540, height: 340 });
+      }
+      
       mpWindow.setMinimizable(true);
       this.windowContext.views.miniPlayerWindow = mpWindow as any;
       this.windowContext.main.hide();
       mpWindow.on("close", () => {
         this.windowContext.main.show();
+        saveState();
       });
       mpId = mpWindow.id;
-    } else {
-      mpId = mpWindow.id;
-      mpWindow.show();
-      // mpWindow.destroy();
-    }
-    this.windowContext.sendToAllViews("miniplayer.state", !this.views.miniPlayerWindow ? null : { active: false });
-    return mpId;
+      } else {
+        mpId = mpWindow.id;
+        mpWindow.show();
+      }
+      this.windowContext.sendToAllViews("miniplayer.state", !this.views.miniPlayerWindow ? null : { active: false });
+      return mpId;
   }
 }

--- a/src/views/mini-player/index.vue
+++ b/src/views/mini-player/index.vue
@@ -48,7 +48,7 @@
       ></div>
     </div>
     <div class="flex flex-col flex-1">
-      <div class="flex flex-col relative z-10 pt-8 px-6 flex-1">
+      <div class="flex flex-col relative z-10 px-6 flex-1 centeronscreen">
         <div class="flex items-start space-x-6">
           <div
             class="track-thumbnail flex flex-shrink-0 items-center shadow justify-center relative"
@@ -500,8 +500,18 @@ export default defineComponent({
   }
 }
 
+.centeronscreen {
+  @apply flex flex-col justify-center;
+}
+
 .track-thumbnail {
-  @apply w-40 h-40 md:h-72 md:w-72 flex-none rounded-lg bg-zinc-800;
+  @apply flex-none rounded-lg bg-zinc-800;
+
+  height: calc(100vh - 10rem);
+  width: calc(100vh - 10rem);
+  max-width: calc(100vw - 16rem);
+  max-height: calc(100vw - 16rem);
+
   img {
     @apply object-cover object-center;
   }


### PR DESCRIPTION
The position of the window is now stored when closing the Mini Player and replicated when opening the mini player again.

Resizing:
|Resized example |Default|
|--------|--------|
| ![grafik](https://github.com/user-attachments/assets/e0b39ebf-36da-4719-bde8-78e8ca9c8018)| ![grafik](https://github.com/user-attachments/assets/e0de609c-eee7-400b-a418-95d1316ed8cd)| 