### PR TITLE
Resize inner HTML when using Window Manager or FancyZones

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -252,6 +252,7 @@ const runApp = async function () {
         });
         youtubeView.setBounds({
           ...youtubeBounds,
+          width: winWidth,
           height: winHeight - toolbarBounds.height,
         });
       }, 100),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -243,20 +243,17 @@ const runApp = async function () {
     win.on(
       "resize",
       debounce(() => {
-        if (fromMaximized && !win.isMaximized()) {
-          const [winWidth, winHeight] = win.getSize(),
-            youtubeBounds = youtubeView.getBounds(),
-            toolbarBounds = toolbarView.getBounds();
-          toolbarView.setBounds({
-            ...toolbarBounds,
-            width: winWidth,
-          });
-          youtubeView.setBounds({
-            ...youtubeBounds,
-            height: winHeight - toolbarBounds.height,
-          });
-          fromMaximized = false;
-        }
+        const [winWidth, winHeight] = win.getSize(),
+          youtubeBounds = youtubeView.getBounds(),
+          toolbarBounds = toolbarView.getBounds();
+        toolbarView.setBounds({
+          ...toolbarBounds,
+          width: winWidth,
+        });
+        youtubeView.setBounds({
+          ...youtubeBounds,
+          height: winHeight - toolbarBounds.height,
+        });
       }, 100),
     );
     youtubeView.webContents.on("page-title-updated", (ev, title) =>


### PR DESCRIPTION
Before:
![grafik](https://github.com/user-attachments/assets/f0f95e8f-5f03-4e2b-a602-557bdbf09de6)
After:
![grafik](https://github.com/user-attachments/assets/a560516d-0a7e-4d47-969b-78223ce350f7)
