### PR TITLE
fix: show install buttons on macOS after update download completes

### DIFF
--- a/src/renderer/src/views/update/index.vue
+++ b/src/renderer/src/views/update/index.vue
@@ -72,7 +72,7 @@
             <button class="w-full px-4 py-2 border border-gray-700 text-gray-300 rounded-md opacity-50 cursor-not-allowed"
                     disabled> Downloading... </button>
           </template>
-          <template v-else-if="updateDownloaded && !isInstalling && !window.api.platform.isMacOS">
+          <template v-else-if="updateDownloaded && !isInstalling">
             <button @click="window.close()"
                     class="flex-1 px-4 py-2 border border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white rounded-md transition-colors"> Later </button>
             <button @click="installUpdate(true)"


### PR DESCRIPTION
## Summary
- Remove `!window.api.platform.isMacOS` condition that hid the "Install Now" / "Later" buttons on macOS after download
- On macOS, if `autoUpdater.quitAndInstall()` fails silently, users were left stuck with no buttons and no way to retry or dismiss

## Test plan
- [ ] On macOS, trigger an update download and verify "Install Now" / "Later" buttons appear after download completes
- [ ] Verify clicking "Install Now" triggers quit-and-install
- [ ] Verify Windows update flow still works as before

Closes #206