### PR TITLE
fix(quit): don't block macOS shutdown/logout

### DIFF
--- a/src/main/utils/handlers/quitHandler.ts
+++ b/src/main/utils/handlers/quitHandler.ts
@@ -1,5 +1,5 @@
 import { platform } from "@electron-toolkit/utils";
-import { app, IpcMainEvent, ipcMain } from "electron";
+import { app, IpcMainEvent, ipcMain, powerMonitor } from "electron";
 import { isDevelopment } from "../devUtils";
 import { BrowserWindowViews } from "../mappedWindow";
 import { ServiceCollection } from "../providerCollection";
@@ -7,6 +7,7 @@ import { setTrayState } from "./trayState";
 
 let isQuitRequested = false;
 let isForceQuitRequested = false;
+let isSystemShutdownRequested = false;
 let isCleanupRunning = false;
 let cleanupPromise: Promise<void> | null = null;
 
@@ -24,7 +25,8 @@ export function attachQuitHandler(mainWindow: BrowserWindowViews<any, any>, serv
 		}
 	};
 
-	const shouldMinimizeToTray = (forceQuit: boolean) => isMinimizeToTrayEnabled() && !forceQuit && !isUpdaterQuitRequested();
+	const shouldMinimizeToTray = (forceQuit: boolean) =>
+		isMinimizeToTrayEnabled() && !forceQuit && !isUpdaterQuitRequested() && !isSystemShutdownRequested;
 
 	const ensureCleanup = async () => {
 		if (!cleanupPromise) {
@@ -43,7 +45,7 @@ export function attachQuitHandler(mainWindow: BrowserWindowViews<any, any>, serv
 			hideToTray();
 			return;
 		}
-		isForceQuitRequested = isForceQuitRequested || forceQuit || isUpdaterQuitRequested();
+		isForceQuitRequested = isForceQuitRequested || forceQuit || isUpdaterQuitRequested() || isSystemShutdownRequested;
 		if (isCleanupRunning || isQuitRequested) return;
 		isCleanupRunning = true;
 		await ensureCleanup();
@@ -60,7 +62,7 @@ export function attachQuitHandler(mainWindow: BrowserWindowViews<any, any>, serv
 			ev.preventDefault();
 			return;
 		}
-		if (isQuitRequested || isForceQuitRequested || isUpdaterQuitRequested()) return;
+		if (isQuitRequested || isForceQuitRequested || isUpdaterQuitRequested() || isSystemShutdownRequested) return;
 		if (shouldMinimizeToTray(false)) {
 			ev.preventDefault();
 			hideToTray();
@@ -71,7 +73,7 @@ export function attachQuitHandler(mainWindow: BrowserWindowViews<any, any>, serv
 	});
 
 	app.on("before-quit", (ev) => {
-		if (isQuitRequested || isForceQuitRequested || isUpdaterQuitRequested()) return;
+		if (isQuitRequested || isForceQuitRequested || isUpdaterQuitRequested() || isSystemShutdownRequested) return;
 		if (shouldMinimizeToTray(false)) {
 			ev.preventDefault();
 			hideToTray();
@@ -85,6 +87,14 @@ export function attachQuitHandler(mainWindow: BrowserWindowViews<any, any>, serv
 		if (!platform.isMacOS || isUpdaterQuitRequested()) {
 			void requestQuit(true);
 		}
+	});
+
+	// macOS/Linux emit this before sending before-quit on OS shutdown/logout.
+	// Flag it so before-quit skips preventDefault() — otherwise the OS treats
+	// the app as refusing to quit and halts the shutdown.
+	powerMonitor.on("shutdown", () => {
+		isSystemShutdownRequested = true;
+		void requestQuit(true);
 	});
 
 	// Exit cleanly on request from parent process in development mode.


### PR DESCRIPTION
## Summary
- Listen on Electron's `powerMonitor.shutdown` event to detect OS-initiated shutdown/restart/logout.
- When that flag is set, `before-quit` and the window `close` handler skip `preventDefault()` so the OS can proceed.
- Also suppresses minimize-to-tray during shutdown — tray minimize was another path that called `preventDefault()` on shutdown.

Fixes #214

## Why
`before-quit` previously called `preventDefault()` unconditionally (either to hide-to-tray or to run async cleanup before `app.quit()`). On macOS, that tells the OS the app refuses to quit, which halts shutdown and forces the user to force-quit the app before the machine can go down.

`powerMonitor.shutdown` fires on macOS and Linux before `before-quit`, giving us a reliable signal to distinguish OS-initiated quits from user/tray-initiated ones.

## Test plan
- [ ] macOS: start the app, trigger Shut Down / Restart / Log Out — confirm the system proceeds without prompting to quit the app manually.
- [ ] macOS: Cmd+Q with minimize-to-tray enabled — confirm it still hides to tray.
- [ ] macOS: Cmd+Q with minimize-to-tray disabled — confirm clean quit with cleanup.
- [ ] Auto-updater install-on-quit path still quits cleanly.
- [ ] Linux: verify `powerMonitor.shutdown` path (logout) doesn't regress normal quit.
- [ ] Windows: no regression (`powerMonitor.shutdown` is a no-op here; existing behavior preserved).