### PR TITLE
feat(lyrics): desktop lyrics overlay (always-on-top, click-through, fill/bar/highlight)

### DIFF
--- a/apps/docs/content/docs/features/lyrics.mdx
+++ b/apps/docs/content/docs/features/lyrics.mdx
@@ -1,14 +1,13 @@
-| **Show line progress** | On | Text fill on the active line| **Dynamic lyrics** | On | Continuously fills the sung text and gently enlarges the current line. |
 ---
 title: Lyrics
-description: Timed lyrics in the YouTube Music Lyrics tab via Better Lyrics, Unison, and LRCLib
+description: Timed lyrics in the YouTube Music Lyrics tab via Better Lyrics, Unison, LRCLib, and YouTube captions
 og:
   image: /images/features-lyrics-player.png
   type: render-auto
   color: "#ff0000"
 ---
 
-When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** tab with timed lines. Providers are tried in your chosen order (default: [Better Lyrics](https://github.com/better-lyrics/better-lyrics) → Unison → [LRCLib](https://lrclib.net)). Syllable/word highlighting appears automatically when the winning provider returns it.
+When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** tab with timed lines. Providers are tried in your chosen order (default: [Better Lyrics](https://github.com/better-lyrics/better-lyrics) → Unison → [LRCLib](https://lrclib.net) → YouTube captions). Syllable/word highlighting appears automatically when the winning provider returns it.
 
 ![Synced lyrics in the player](/images/features-lyrics-player.png)
 
@@ -24,10 +23,12 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 | Setting | Default | What it does |
 | --- | --- | --- |
 | **Enable lyrics** | Off | Hijacks the Lyrics tab (hot-toggle, no app restart). |
+| **Dynamic lyrics** | On | Continuously fills the sung text and gently enlarges the current line. |
 | **Allow approximate matches** | On | For LRCLib, show lyrics when title/artist match is close but not exact. |
 | **Show time codes** | Off | Two-column layout with a right-aligned timestamp per line. |
-| **Show line progress** | On | Muted fill on the active line when there are no word/syllable cues. |
-| **Providers** | Better Lyrics → Unison → LRCLib | Separate card: drag to reorder; toggle each source on/off. |
+| **Show line progress** | On | Text fill on the active line when there are no word/syllable cues. |
+| **Providers** | Better Lyrics → Unison → LRCLib → YouTube captions | Separate card: drag to reorder; toggle each source on/off. |
+| **Better Lyrics API key** | Empty | Optional `X-API-Key` for the Better Lyrics API. Only needed for songs that aren't cached yet. |
 
 ## Providers
 
@@ -35,7 +36,19 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 | --- | --- |
 | **Better Lyrics** | Syllable & line (TTML) |
 | **[Unison](https://github.com/better-lyrics/unison)** | Syllable, line & plain |
-| **LRCLib** | Line & plain |
+| **LRCLib** | Word (enhanced LRC), line & plain |
+| **YouTube captions** | Line — the video's own human-made caption track; auto-generated captions are ignored |
+
+The Better Lyrics provider uses its documented [public API](https://lyrics-api-docs.boidu.dev), which is **cache-first**: songs already in its cache are free for anyone, while a song that has never been requested needs an API key to fetch from upstream. Better Lyrics is [not issuing new keys](https://lyrics-api-docs.boidu.dev/docs/authentication) at the moment, so for an uncached song YTMDesktop2 falls through to Unison, LRCLib and YouTube captions, and shows a hint in the Lyrics tab.
+
+To get an uncached song into Better Lyrics yourself:
+
+1. Play it once in YouTube Music with the [Better Lyrics browser extension](https://better-lyrics.boidu.dev) installed. The extension fetches through the same upstream, so after one playback the song is cached for every caller — including YTMDesktop2.
+2. Or, if you have the lyrics, upload them at [unison.boidu.dev](https://unison.boidu.dev).
+
+If you already have a Better Lyrics API key, paste it into **Better Lyrics API key** under the Providers card. Changing the key clears the session cache and refetches the current track.
+
+**YouTube captions** reads the caption track YouTube already serves for the current video — useful for music videos and live sessions with a human-made caption track. Auto-generated captions are skipped because speech recognition mishears sung lyrics. Because the player only exposes captions for the video that is playing, this source is not consulted when pre-fetching the next queued track.
 
 ## Notes
 

--- a/apps/docs/content/docs/features/lyrics.mdx
+++ b/apps/docs/content/docs/features/lyrics.mdx
@@ -24,11 +24,11 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 | --- | --- | --- |
 | **Enable lyrics** | Off | Hijacks the Lyrics tab (hot-toggle, no app restart). |
 | **Auto-open Lyrics tab** | On | Switches the player page to the Lyrics tab when lyrics for a new track are found (once per track). |
-| **Dynamic lyrics** | On | Continuously fills the sung text and gently enlarges the current line. |
+| **Dynamic lyrics** | On | Continuously fills word/syllable-synced text and gently enlarges the current line. Line-only lyrics just highlight and enlarge. |
 | **Prefer word-synced sources** | On | Keeps trying later providers for word/syllable timing before settling for a line-synced hit. Off = first timed result wins. |
 | **Allow approximate matches** | On | For LRCLib, show lyrics when title/artist match is close but not exact. |
 | **Show time codes** | Off | Two-column layout with a right-aligned timestamp per line. |
-| **Show line progress** | On | Text fill on the active line when there are no word/syllable cues. |
+| **Show line progress** | On | Row progress on the active line when there are no word/syllable cues (only with Dynamic lyrics off). |
 | **Providers** | Better Lyrics → Unison → LRCLib → YouTube captions | Separate card: drag to reorder; toggle each source on/off. |
 | **Better Lyrics API key** | Empty | Optional `X-API-Key` for the Better Lyrics API. Only needed for songs that aren't cached yet. |
 
@@ -58,7 +58,7 @@ If you already have a Better Lyrics API key, paste it into **Better Lyrics API k
 - Changing provider order clears the session cache and refetches for the current track.
 - Ads, live, podcasts, and very short clips are skipped.
 - Overlapping timed lines can all be active at once; scroll follows the latest-started.
-- With **Dynamic lyrics** enabled, word/syllable cues fill continuously in the text as they are sung. The current line gently enlarges without changing text wrapping; line-only lyrics use the same text-fill treatment.
+- With **Dynamic lyrics** enabled, word/syllable cues fill continuously in the text as they are sung. The current line gently enlarges without changing text wrapping. Line-only lyrics don't fill — a line cue only says when the line starts, not how its words are paced, so a constant-rate fill would drift from the vocal; the active line simply highlights and enlarges.
 - Scrolling manually pauses automatic centering for 2.5 seconds. Resizing the panel recenters the current line once that pause ends.
 - The system's reduced-motion preference disables line scaling and smooth scrolling while keeping timing highlights visible.
 - Disable anytime to restore stock YouTube Music lyrics.

--- a/apps/docs/content/docs/features/lyrics.mdx
+++ b/apps/docs/content/docs/features/lyrics.mdx
@@ -24,11 +24,11 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 | --- | --- | --- |
 | **Enable lyrics** | Off | Hijacks the Lyrics tab (hot-toggle, no app restart). |
 | **Auto-open Lyrics tab** | On | Switches the player page to the Lyrics tab when lyrics for a new track are found (once per track). |
-| **Dynamic lyrics** | On | Continuously fills word/syllable-synced text and gently enlarges the current line. Line-only lyrics just highlight and enlarge. |
+| **Dynamic lyrics** | On | Continuously fills word/syllable-synced text and gently enlarges the current line. Line-only lyrics follow **Line-synced style**. |
 | **Prefer word-synced sources** | On | Keeps trying later providers for word/syllable timing before settling for a line-synced hit. Off = first timed result wins. |
 | **Allow approximate matches** | On | For LRCLib, show lyrics when title/artist match is close but not exact. |
 | **Show time codes** | Off | Two-column layout with a right-aligned timestamp per line. |
-| **Show line progress** | On | Row progress on the active line when there are no word/syllable cues (only with Dynamic lyrics off). |
+| **Line-synced style** | Highlight only | How the current line shows progress when there are no word/syllable cues: **Highlight only** (light up / enlarge, no indicator), **Progress bar** (row background advances), or **Text fill** (text turns white left to right). Bar and fill run at a constant rate since line timing has no per-word pacing. |
 | **Providers** | Better Lyrics → Unison → LRCLib → YouTube captions | Separate card: drag to reorder; toggle each source on/off. |
 | **Better Lyrics API key** | Empty | Optional `X-API-Key` for the Better Lyrics API. Only needed for songs that aren't cached yet. |
 
@@ -58,7 +58,7 @@ If you already have a Better Lyrics API key, paste it into **Better Lyrics API k
 - Changing provider order clears the session cache and refetches for the current track.
 - Ads, live, podcasts, and very short clips are skipped.
 - Overlapping timed lines can all be active at once; scroll follows the latest-started.
-- With **Dynamic lyrics** enabled, word/syllable cues fill continuously in the text as they are sung. The current line gently enlarges without changing text wrapping. Line-only lyrics don't fill — a line cue only says when the line starts, not how its words are paced, so a constant-rate fill would drift from the vocal; the active line simply highlights and enlarges.
+- With **Dynamic lyrics** enabled, word/syllable cues fill continuously in the text as they are sung. The current line gently enlarges without changing text wrapping. Line-only lyrics use **Line-synced style** — by default the active line simply highlights and enlarges, because a line cue only says when the line starts, not how its words are paced, so a constant-rate bar or fill can drift from the vocal. Pick **Progress bar** or **Text fill** if you'd rather see an indicator anyway.
 - Scrolling manually pauses automatic centering for 2.5 seconds. Resizing the panel recenters the current line once that pause ends.
 - The system's reduced-motion preference disables line scaling and smooth scrolling while keeping timing highlights visible.
 - Disable anytime to restore stock YouTube Music lyrics.

--- a/apps/docs/content/docs/features/lyrics.mdx
+++ b/apps/docs/content/docs/features/lyrics.mdx
@@ -1,3 +1,4 @@
+| **Show line progress** | On | Text fill on the active line| **Dynamic lyrics** | On | Continuously fills the sung text and gently enlarges the current line. |
 ---
 title: Lyrics
 description: Timed lyrics in the YouTube Music Lyrics tab via Better Lyrics, Unison, and LRCLib
@@ -42,6 +43,9 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 - Changing provider order clears the session cache and refetches for the current track.
 - Ads, live, podcasts, and very short clips are skipped.
 - Overlapping timed lines can all be active at once; scroll follows the latest-started.
+- With **Dynamic lyrics** enabled, word/syllable cues fill continuously in the text as they are sung. The current line gently enlarges without changing text wrapping; line-only lyrics use the same text-fill treatment.
+- Scrolling manually pauses automatic centering for 2.5 seconds. Resizing the panel recenters the current line once that pause ends.
+- The system's reduced-motion preference disables line scaling and smooth scrolling while keeping timing highlights visible.
 - Disable anytime to restore stock YouTube Music lyrics.
 
 ## Related

--- a/apps/docs/content/docs/features/lyrics.mdx
+++ b/apps/docs/content/docs/features/lyrics.mdx
@@ -24,11 +24,11 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 | --- | --- | --- |
 | **Enable lyrics** | Off | Hijacks the Lyrics tab (hot-toggle, no app restart). |
 | **Auto-open Lyrics tab** | On | Switches the player page to the Lyrics tab when lyrics for a new track are found (once per track). |
-| **Dynamic lyrics** | On | Continuously fills word/syllable-synced text and gently enlarges the current line. Line-only lyrics follow **Line-synced style**. |
 | **Prefer word-synced sources** | On | Keeps trying later providers for word/syllable timing before settling for a line-synced hit. Off = first timed result wins. |
 | **Allow approximate matches** | On | For LRCLib, show lyrics when title/artist match is close but not exact. |
 | **Show time codes** | Off | Two-column layout with a right-aligned timestamp per line. |
-| **Line-synced style** | Highlight only | How the current line shows progress when there are no word/syllable cues: **Highlight only** (light up / enlarge, no indicator), **Progress bar** (row background advances), or **Text fill** (text turns white left to right). Bar and fill run at a constant rate since line timing has no per-word pacing. |
+| **Active line background** | On | Tints the row behind the current line. Off = only the text brightens (the Progress bar style still draws its bar; Text fill is unaffected). |
+| **Highlight style** | Text fill | **Highlight only** (light the line up; word-synced lyrics step word by word), **Text fill** (word-synced lyrics: each word sweeps to white over its duration — songs with line timing only fall back to Highlight only), or **Progress bar** (line-timing songs: row background advances at a constant rate). |
 | **Providers** | Better Lyrics → Unison → LRCLib → YouTube captions | Separate card: drag to reorder; toggle each source on/off. |
 | **Better Lyrics API key** | Empty | Optional `X-API-Key` for the Better Lyrics API. Only needed for songs that aren't cached yet. |
 
@@ -58,9 +58,9 @@ If you already have a Better Lyrics API key, paste it into **Better Lyrics API k
 - Changing provider order clears the session cache and refetches for the current track.
 - Ads, live, podcasts, and very short clips are skipped.
 - Overlapping timed lines can all be active at once; scroll follows the latest-started.
-- With **Dynamic lyrics** enabled, word/syllable cues fill continuously in the text as they are sung. The current line gently enlarges without changing text wrapping. Line-only lyrics use **Line-synced style** — by default the active line simply highlights and enlarges, because a line cue only says when the line starts, not how its words are paced, so a constant-rate bar or fill can drift from the vocal. Pick **Progress bar** or **Text fill** if you'd rather see an indicator anyway.
+- **Text fill** only sweeps when the provider returned word/syllable timing. A line cue only says when the line starts, not how its words are paced, so line-only songs simply highlight instead of filling at a guessed rate. **Progress bar** is the opt-in constant-rate indicator for those songs.
 - Scrolling manually pauses automatic centering for 2.5 seconds. Resizing the panel recenters the current line once that pause ends.
-- The system's reduced-motion preference disables line scaling and smooth scrolling while keeping timing highlights visible.
+- The system's reduced-motion preference disables smooth scrolling and transitions while keeping timing highlights visible.
 - Disable anytime to restore stock YouTube Music lyrics.
 
 ## Related

--- a/apps/docs/content/docs/features/lyrics.mdx
+++ b/apps/docs/content/docs/features/lyrics.mdx
@@ -23,7 +23,9 @@ When **Lyrics** is enabled, YTMDesktop2 replaces the YouTube Music **Lyrics** ta
 | Setting | Default | What it does |
 | --- | --- | --- |
 | **Enable lyrics** | Off | Hijacks the Lyrics tab (hot-toggle, no app restart). |
+| **Auto-open Lyrics tab** | On | Switches the player page to the Lyrics tab when lyrics for a new track are found (once per track). |
 | **Dynamic lyrics** | On | Continuously fills the sung text and gently enlarges the current line. |
+| **Prefer word-synced sources** | On | Keeps trying later providers for word/syllable timing before settling for a line-synced hit. Off = first timed result wins. |
 | **Allow approximate matches** | On | For LRCLib, show lyrics when title/artist match is close but not exact. |
 | **Show time codes** | Off | Two-column layout with a right-aligned timestamp per line. |
 | **Show line progress** | On | Text fill on the active line when there are no word/syllable cues. |

--- a/apps/ytmdesktop2/src/main/domain/trayMenu.ts
+++ b/apps/ytmdesktop2/src/main/domain/trayMenu.ts
@@ -1,7 +1,9 @@
 import { BaseProvider } from "@main/core/baseProvider";
 import { serverMain } from "@main/ipc/serverEvents";
 import AppProvider from "@main/trpc/routers/app/service";
+import LyricsProvider from "@main/trpc/routers/lyrics/service";
 import SettingsProvider from "@main/trpc/routers/settings/service";
+import { readLyricsOverlaySettings } from "@shared/lyrics/overlay";
 import translations from "@translations/index";
 import { Menu, shell } from "electron";
 
@@ -11,6 +13,8 @@ export const createTrayMenu = (provider: BaseProvider) => {
 	const appProvider = provider.getProvider("app") as AppProvider;
 	const { app } = appProvider;
 	const update = provider.getProvider("update");
+	const lyrics = provider.getProvider("lyrics") as LyricsProvider;
+	const lyricsOverlay = readLyricsOverlaySettings(sp.lyrics?.overlay);
 	const menu = Menu.buildFromTemplate([
 		{
 			label: translations.appName,
@@ -84,6 +88,38 @@ export const createTrayMenu = (provider: BaseProvider) => {
 					click: (item) => {
 						settings.set("discord.buttons", item.checked);
 					},
+				},
+			],
+		},
+		{
+			type: "separator",
+		},
+		{
+			type: "submenu",
+			label: "Desktop Lyrics",
+			submenu: [
+				{
+					label: "Show Desktop Lyrics",
+					type: "checkbox",
+					enabled: !!sp.lyrics?.enabled,
+					checked: !!sp.lyrics?.enabled && lyricsOverlay.enabled,
+					click: (item) => {
+						settings.set("lyrics.overlay.enabled", item.checked);
+					},
+				},
+				{
+					label: "Lock (click-through)",
+					type: "checkbox",
+					enabled: !!sp.lyrics?.enabled && lyricsOverlay.enabled,
+					checked: lyricsOverlay.locked,
+					click: (item) => {
+						settings.set("lyrics.overlay.locked", item.checked);
+					},
+				},
+				{
+					label: "Reset Position",
+					enabled: lyricsOverlay.enabled,
+					click: () => lyrics.resetOverlayPosition(),
 				},
 			],
 		},

--- a/apps/ytmdesktop2/src/main/trpc/router.ts
+++ b/apps/ytmdesktop2/src/main/trpc/router.ts
@@ -4,9 +4,10 @@
 import { apiRouter } from "@main/trpc/routers/api";
 import { appServiceRouter } from "@main/trpc/routers/app";
 import { authRouter } from "@main/trpc/routers/auth";
-import { discordRouter } from "@main/trpc/routers/discord";
 import { chromecastRouter } from "@main/trpc/routers/chromecast";
+import { discordRouter } from "@main/trpc/routers/discord";
 import { lastfmRouter } from "@main/trpc/routers/lastfm";
+import { lyricsRouter } from "@main/trpc/routers/lyrics";
 import { navigationRouter } from "@main/trpc/routers/navigation";
 import { settingsRouter } from "@main/trpc/routers/settings";
 import { themesRouter } from "@main/trpc/routers/themes";
@@ -34,6 +35,7 @@ export const appRouter = router({
 	trayView: trayViewRouter,
 	themes: themesRouter,
 	lastfm: lastfmRouter,
+	lyrics: lyricsRouter,
 	chromecast: chromecastRouter,
 	window: windowRouter,
 	discord: discordRouter,

--- a/apps/ytmdesktop2/src/main/trpc/routers/lyrics/index.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/lyrics/index.ts
@@ -1,0 +1,1 @@
+export { lyricsRouter } from "./router";

--- a/apps/ytmdesktop2/src/main/trpc/routers/lyrics/router.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/lyrics/router.ts
@@ -1,0 +1,24 @@
+import { fromIpcEvent } from "@main/trpc/fromIpcEvent";
+import { provider } from "@main/trpc/provider";
+import {
+	LYRICS_OVERLAY_EVENTS,
+	type LyricsOverlayClock,
+	type LyricsOverlaySnapshot,
+	type LyricsOverlayWindowState,
+} from "@shared/lyrics/overlay";
+import { publicProcedure, router } from "@shared/trpc/trpc";
+import { z } from "zod";
+
+export const lyricsRouter = router({
+	overlaySnapshot: publicProcedure.query(({ ctx }): LyricsOverlaySnapshot => provider(ctx, "lyrics").getOverlaySnapshot()),
+	overlayClock: publicProcedure.query(({ ctx }): LyricsOverlayClock | null => provider(ctx, "lyrics").getOverlayClock()),
+	overlayState: publicProcedure.query(({ ctx }): LyricsOverlayWindowState => provider(ctx, "lyrics").getOverlayState()),
+	setOverlayEnabled: publicProcedure.input(z.boolean()).mutation(({ ctx, input }): boolean => provider(ctx, "lyrics").setOverlayEnabled(input)),
+	toggleOverlay: publicProcedure.mutation(({ ctx }): boolean => provider(ctx, "lyrics").toggleOverlay()),
+	setOverlayLocked: publicProcedure.input(z.boolean()).mutation(({ ctx, input }): boolean => provider(ctx, "lyrics").setOverlayLocked(input)),
+	toggleOverlayLocked: publicProcedure.mutation(({ ctx }): boolean => provider(ctx, "lyrics").toggleOverlayLocked()),
+	resetOverlayPosition: publicProcedure.mutation(({ ctx }): void => provider(ctx, "lyrics").resetOverlayPosition()),
+	onOverlaySnapshot: publicProcedure.subscription(() => fromIpcEvent<LyricsOverlaySnapshot>(LYRICS_OVERLAY_EVENTS.snapshot)),
+	onOverlayClock: publicProcedure.subscription(() => fromIpcEvent<LyricsOverlayClock>(LYRICS_OVERLAY_EVENTS.clock)),
+	onOverlayState: publicProcedure.subscription(() => fromIpcEvent<LyricsOverlayWindowState>(LYRICS_OVERLAY_EVENTS.state)),
+});

--- a/apps/ytmdesktop2/src/main/trpc/routers/lyrics/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/lyrics/service.ts
@@ -1,20 +1,294 @@
-import { AfterInit, BaseProvider } from "@main/core/baseProvider";
+import { AfterInit, BaseProvider, OnDestroy } from "@main/core/baseProvider";
+import { isAppQuitting, shouldCancelWindowClose } from "@main/handlers/quitPolicy";
+import { serverMain } from "@main/ipc/serverEvents";
+import SettingsProvider from "@main/trpc/routers/settings/service";
+import { createAppWindow, wrapWindowHandler } from "@main/windows/windowUtils";
+import {
+	EMPTY_LYRICS_OVERLAY_SNAPSHOT,
+	LYRICS_OVERLAY_DEFAULT_SIZE,
+	LYRICS_OVERLAY_EVENTS,
+	LYRICS_OVERLAY_IPC,
+	LYRICS_OVERLAY_MIN_SIZE,
+	type LyricsOverlayClock,
+	type LyricsOverlaySnapshot,
+	type LyricsOverlayWindowState,
+	readLyricsOverlaySettings,
+} from "@shared/lyrics/overlay";
+import { BrowserWindow, type Rectangle, screen } from "electron";
+import { debounce } from "lodash-es";
 
-/** Hot-toggles youtube `lyrics` plugin via settings → IPC cmds. */
-export default class LyricsProvider extends BaseProvider implements AfterInit {
+/** Gap between the overlay's bottom edge and the taskbar when no saved position exists. */
+const OVERLAY_BOTTOM_MARGIN = 48;
+
+function isSnapshot(value: unknown): value is LyricsOverlaySnapshot {
+	const v = value as LyricsOverlaySnapshot | null;
+	return !!v && typeof v === "object" && typeof v.status === "string" && (v.lines === null || Array.isArray(v.lines));
+}
+
+function isClock(value: unknown): value is LyricsOverlayClock {
+	const v = value as LyricsOverlayClock | null;
+	return !!v && typeof v === "object" && typeof v.timeMs === "number" && typeof v.playing === "boolean" && typeof v.at === "number";
+}
+
+/** Keep a saved rectangle on-screen (display removed / resolution changed). */
+function clampToWorkArea(bounds: Rectangle): Rectangle {
+	const area = screen.getDisplayMatching(bounds).workArea;
+	const width = Math.min(Math.max(bounds.width, LYRICS_OVERLAY_MIN_SIZE.width), area.width);
+	const height = Math.min(Math.max(bounds.height, LYRICS_OVERLAY_MIN_SIZE.height), area.height);
+	return {
+		width,
+		height,
+		x: Math.round(Math.min(Math.max(bounds.x, area.x), area.x + area.width - width)),
+		y: Math.round(Math.min(Math.max(bounds.y, area.y), area.y + area.height - height)),
+	};
+}
+
+function bottomCenterBounds(width: number, height: number): Rectangle {
+	const area = screen.getPrimaryDisplay().workArea;
+	return {
+		width,
+		height,
+		x: Math.round(area.x + (area.width - width) / 2),
+		y: Math.round(area.y + area.height - height - OVERLAY_BOTTOM_MARGIN),
+	};
+}
+
+/**
+ * Hot-toggles the youtube `lyrics` plugin via settings → IPC cmds, and owns the desktop lyrics
+ * overlay: an always-on-top transparent window fed by the plugin (snapshot + low-rate clock).
+ */
+export default class LyricsProvider extends BaseProvider implements AfterInit, OnDestroy {
+	private _overlayWindow: BrowserWindow | undefined;
+	private _overlayReady: Promise<BrowserWindow> | null = null;
+	private _snapshot: LyricsOverlaySnapshot = EMPTY_LYRICS_OVERLAY_SNAPSHOT;
+	private _clock: LyricsOverlayClock | null = null;
+	private _saveOverlayBounds: (() => void) | null = null;
+	private _settingsWired = false;
+	private persistOverlayBounds = debounce(() => this._saveOverlayBounds?.(), 250);
+
 	constructor() {
 		super("lyrics");
+		this.bindIpc();
 	}
 
-	get settingsInstance() {
+	get settingsInstance(): SettingsProvider {
 		return this.getProvider("settings");
 	}
 
-	async AfterInit() {
-		this.settingsInstance.onSettingChange("lyrics.enabled", (value) => void this.__onToggle(value), {
-			debounce: 300,
+	private bindIpc() {
+		serverMain.on(LYRICS_OVERLAY_IPC.snapshot, (_ev: unknown, snap: unknown) => {
+			if (!isSnapshot(snap)) return;
+			this._snapshot = snap;
+			serverMain.emit(LYRICS_OVERLAY_EVENTS.snapshot, snap);
+		});
+		serverMain.on(LYRICS_OVERLAY_IPC.clock, (_ev: unknown, clock: unknown) => {
+			if (!isClock(clock)) return;
+			this._clock = clock;
+			serverMain.emit(LYRICS_OVERLAY_EVENTS.clock, clock);
 		});
 	}
+
+	async AfterInit() {
+		const settings = this.settingsInstance;
+		if (!this._settingsWired) {
+			this._settingsWired = true;
+			settings.onSettingChange("lyrics.enabled", (value) => void this.__onToggle(value), {
+				debounce: 300,
+			});
+			settings.onSettingChange("lyrics.overlay.enabled", (value) => {
+				if (value) void this.openOverlay();
+				else this.closeOverlay();
+			});
+			settings.onSettingChange("lyrics.overlay.locked", () => this.applyOverlayLock());
+		}
+		if (this.overlaySettings.enabled) {
+			try {
+				await this.openOverlay();
+			} catch (err) {
+				this.logger.error("lyrics overlay restore failed", err);
+			}
+		}
+	}
+
+	async OnDestroy() {
+		this.persistOverlayBounds.cancel();
+		const win = this.getOverlayWindow();
+		if (win) {
+			this._saveOverlayBounds?.();
+			win.destroy();
+		}
+	}
+
+	// ---- overlay feed -------------------------------------------------------------------------
+
+	get overlaySettings() {
+		return readLyricsOverlaySettings(this.settingsInstance.get("lyrics.overlay"));
+	}
+
+	getOverlaySnapshot(): LyricsOverlaySnapshot {
+		return this._snapshot;
+	}
+
+	getOverlayClock(): LyricsOverlayClock | null {
+		return this._clock;
+	}
+
+	getOverlayState(): LyricsOverlayWindowState {
+		return { open: !!this.getOverlayWindow(), locked: this.overlaySettings.locked };
+	}
+
+	private emitOverlayState() {
+		serverMain.emit(LYRICS_OVERLAY_EVENTS.state, this.getOverlayState());
+	}
+
+	// ---- overlay window -----------------------------------------------------------------------
+
+	private getOverlayWindow(): BrowserWindow | null {
+		const win = this._overlayWindow;
+		if (!win || win.isDestroyed()) return null;
+		return win;
+	}
+
+	/** Setting-driven entry points: the setting is the source of truth so tray / settings UI / window stay in sync. */
+	setOverlayEnabled(enabled: boolean): boolean {
+		this.settingsInstance.set("lyrics.overlay.enabled", enabled);
+		this.settingsInstance.saveToDrive();
+		return enabled;
+	}
+
+	toggleOverlay(): boolean {
+		return this.setOverlayEnabled(!this.overlaySettings.enabled);
+	}
+
+	setOverlayLocked(locked: boolean): boolean {
+		this.settingsInstance.set("lyrics.overlay.locked", locked);
+		this.settingsInstance.saveToDrive();
+		return locked;
+	}
+
+	toggleOverlayLocked(): boolean {
+		return this.setOverlayLocked(!this.overlaySettings.locked);
+	}
+
+	/** Nudge the window back to the primary display's bottom centre (lost off-screen / multi-monitor changes). */
+	resetOverlayPosition(): void {
+		const win = this.getOverlayWindow();
+		if (!win) return;
+		const { width, height } = win.getBounds();
+		win.setBounds(bottomCenterBounds(width, height));
+		this.persistOverlayBounds();
+	}
+
+	async openOverlay(): Promise<void> {
+		const win = await this.ensureOverlayWindow();
+		if (win.isDestroyed()) return;
+		if (!win.isVisible()) win.showInactive();
+		this.applyOverlayLock(win);
+		this.emitOverlayState();
+	}
+
+	closeOverlay(): void {
+		this.persistOverlayBounds.cancel();
+		const win = this.getOverlayWindow();
+		if (!win) return;
+		this._saveOverlayBounds?.();
+		this._saveOverlayBounds = null;
+		win.destroy();
+		this._overlayWindow = undefined;
+		this.emitOverlayState();
+	}
+
+	/**
+	 * Locked = click-through, unfocusable, frozen bounds — the QQ Music style "pin it and forget it".
+	 * Unlocked = movable (drag bar in the page) and resizable via the native frameless borders.
+	 */
+	private applyOverlayLock(win: BrowserWindow | null = this.getOverlayWindow()) {
+		if (!win || win.isDestroyed()) return;
+		const { locked } = this.overlaySettings;
+		try {
+			if (locked) win.setIgnoreMouseEvents(true);
+			else win.setIgnoreMouseEvents(false);
+			win.setResizable(!locked);
+			win.setMovable(!locked);
+			win.setFocusable(!locked);
+			if (locked && win.isFocused()) win.blur();
+		} catch (err) {
+			this.logger.warn("lyrics overlay lock flags failed", err);
+		}
+		this.emitOverlayState();
+	}
+
+	private async ensureOverlayWindow(): Promise<BrowserWindow> {
+		const existing = this.getOverlayWindow();
+		if (existing) return existing;
+		if (this._overlayReady) return this._overlayReady;
+
+		this._overlayReady = (async () => {
+			const win = await createAppWindow({
+				path: "/lyrics-overlay",
+				width: LYRICS_OVERLAY_DEFAULT_SIZE.width,
+				height: LYRICS_OVERLAY_DEFAULT_SIZE.height,
+				minWidth: LYRICS_OVERLAY_MIN_SIZE.width,
+				minHeight: LYRICS_OVERLAY_MIN_SIZE.height,
+				show: false,
+				showTaskBar: false,
+				minimizeable: false,
+				maximizeable: false,
+				devtools: false,
+				transparent: true,
+				extraOptions: {
+					title: "Lyrics",
+					alwaysOnTop: true,
+					fullscreenable: false,
+					webPreferences: { backgroundThrottling: false },
+				},
+			});
+			// "screen-saver" is the highest macOS level; on Windows every level maps to HWND_TOPMOST.
+			win.setAlwaysOnTop(true, "screen-saver");
+			win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
+			win.setMenuBarVisibility(false);
+			win.webContents.setBackgroundThrottling(false);
+
+			const { state, saveState, restored } = await wrapWindowHandler(win, "lyrics-overlay", {
+				width: LYRICS_OVERLAY_DEFAULT_SIZE.width,
+				height: LYRICS_OVERLAY_DEFAULT_SIZE.height,
+			});
+			this._saveOverlayBounds = saveState;
+			if (restored && typeof state?.x === "number" && typeof state?.y === "number") {
+				win.setBounds(clampToWorkArea({ x: state.x, y: state.y, width: state.width, height: state.height }));
+			} else {
+				win.setBounds(bottomCenterBounds(LYRICS_OVERLAY_DEFAULT_SIZE.width, LYRICS_OVERLAY_DEFAULT_SIZE.height));
+			}
+			win.on("moved", () => this.persistOverlayBounds());
+			win.on("resized", () => this.persistOverlayBounds());
+
+			// Alt+F4 / window close → treat as "turn the overlay off" instead of leaving the setting stale.
+			win.on("close", (ev) => {
+				if (!shouldCancelWindowClose({ quitting: isAppQuitting() })) return;
+				ev.preventDefault();
+				// Destroying from inside our own `close` handler is fragile — flip the setting on the next tick.
+				setImmediate(() => this.setOverlayEnabled(false));
+			});
+			win.on("closed", () => {
+				if (this._overlayWindow === win) this._overlayWindow = undefined;
+				this.emitOverlayState();
+			});
+
+			this._overlayWindow = win;
+			return win;
+		})();
+
+		try {
+			return await this._overlayReady;
+		} catch (err) {
+			this._overlayWindow = undefined;
+			throw err;
+		} finally {
+			this._overlayReady = null;
+		}
+	}
+
+	// ---- plugin toggle ------------------------------------------------------------------------
 
 	private async __onToggle(value: unknown) {
 		if (value) await this.enable();

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
@@ -105,6 +105,7 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 				showTimeCodes: false,
 				showEvenIfInexact: true,
 				showProgressBar: true,
+				dynamicLyrics: true,
 				providers: [
 					{ id: "better-lyrics", enabled: true },
 					{ id: "unison", enabled: true },

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
@@ -1,5 +1,6 @@
 import { platform } from "@electron-toolkit/utils";
 import type { LegacyCustomCssConfig } from "@main/trpc/routers/themes/types";
+import { readLyricsOverlaySettings } from "@shared/lyrics/overlay";
 import { app } from "electron";
 import { Migration } from "electron-conf";
 import { readFileSync, rmSync, statSync } from "fs";
@@ -192,6 +193,22 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 				store.set("lyrics.lineStyle", "fill");
 			}
 			if (typeof current.lineBackground !== "boolean") store.set("lyrics.lineBackground", true);
+		},
+	},
+	{
+		hook(store) {
+			const current = (store.store as SettingsStore)?.lyrics;
+			if (!current) return;
+			// Desktop overlay lands closed and unlocked; `readLyricsOverlaySettings` fills any missing field.
+			store.set("lyrics.overlay", readLyricsOverlaySettings(current.overlay));
+		},
+	},
+	{
+		hook(store) {
+			const current = (store.store as SettingsStore)?.lyrics;
+			if (!current) return;
+			// Overlay gained outline / shadow / next-line / bar colours — backfill defaults, keep user values.
+			store.set("lyrics.overlay", readLyricsOverlaySettings(current.overlay));
 		},
 	},
 ];

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
@@ -110,7 +110,9 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 					{ id: "better-lyrics", enabled: true },
 					{ id: "unison", enabled: true },
 					{ id: "lrclib", enabled: true },
+					{ id: "youtube-captions", enabled: true },
 				],
+				betterLyricsApiKey: "",
 			});
 		},
 	},
@@ -128,6 +130,7 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 					{ id: "better-lyrics", enabled: true },
 					{ id: "unison", enabled: true },
 					{ id: "lrclib", enabled: true },
+					{ id: "youtube-captions", enabled: true },
 				]);
 				return;
 			}
@@ -159,6 +162,18 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 				pinned = false;
 			}
 			store.set("trayView.pinned", pinned);
+		},
+	},
+	{
+		hook(store) {
+			const current = (store.store as SettingsStore)?.lyrics;
+			if (!current) return;
+			if (typeof current.betterLyricsApiKey !== "string") store.set("lyrics.betterLyricsApiKey", "");
+			// New last-resort provider: append (enabled) for users with an older saved order.
+			const providers = Array.isArray(current.providers) ? current.providers : [];
+			if (providers.length && !providers.some((p) => p?.id === "youtube-captions")) {
+				store.set("lyrics.providers", [...providers, { id: "youtube-captions", enabled: true }]);
+			}
 		},
 	},
 ];

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
@@ -113,6 +113,8 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 					{ id: "youtube-captions", enabled: true },
 				],
 				betterLyricsApiKey: "",
+				autoOpenTab: true,
+				preferWordSync: true,
 			});
 		},
 	},
@@ -169,6 +171,8 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 			const current = (store.store as SettingsStore)?.lyrics;
 			if (!current) return;
 			if (typeof current.betterLyricsApiKey !== "string") store.set("lyrics.betterLyricsApiKey", "");
+			if (typeof current.autoOpenTab !== "boolean") store.set("lyrics.autoOpenTab", true);
+			if (typeof current.preferWordSync !== "boolean") store.set("lyrics.preferWordSync", true);
 			// New last-resort provider: append (enabled) for users with an older saved order.
 			const providers = Array.isArray(current.providers) ? current.providers : [];
 			if (providers.length && !providers.some((p) => p?.id === "youtube-captions")) {

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
@@ -104,8 +104,8 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 				enabled: false,
 				showTimeCodes: false,
 				showEvenIfInexact: true,
-				lineStyle: "highlight",
-				dynamicLyrics: true,
+				lineBackground: true,
+				lineStyle: "fill",
 				providers: [
 					{ id: "better-lyrics", enabled: true },
 					{ id: "unison", enabled: true },
@@ -184,13 +184,14 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 		hook(store) {
 			const current = (store.store as SettingsStore)?.lyrics as (SettingsStore["lyrics"] & { showProgressBar?: unknown }) | undefined;
 			if (!current) return;
-			// `showProgressBar` (bool) became `lineStyle`. The old default drew a constant-rate text fill
-			// that drifted from the vocal, so everyone lands on the new "highlight" default rather than
-			// mapping true → fill.
+			// `showProgressBar` (bool) became `lineStyle`. The old bool drew a constant-rate line fill;
+			// the new "fill" only sweeps word-synced lines (line-only songs just highlight), so it is a
+			// safe default for everyone rather than mapping true/false individually.
 			if ("showProgressBar" in current) store.delete("lyrics.showProgressBar" as keyof SettingsStore);
 			if (current.lineStyle !== "highlight" && current.lineStyle !== "bar" && current.lineStyle !== "fill") {
-				store.set("lyrics.lineStyle", "highlight");
+				store.set("lyrics.lineStyle", "fill");
 			}
+			if (typeof current.lineBackground !== "boolean") store.set("lyrics.lineBackground", true);
 		},
 	},
 ];

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/migrations.ts
@@ -104,7 +104,7 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 				enabled: false,
 				showTimeCodes: false,
 				showEvenIfInexact: true,
-				showProgressBar: true,
+				lineStyle: "highlight",
 				dynamicLyrics: true,
 				providers: [
 					{ id: "better-lyrics", enabled: true },
@@ -177,6 +177,19 @@ const migrations: Omit<Migration<SettingsStore>, "version">[] = [
 			const providers = Array.isArray(current.providers) ? current.providers : [];
 			if (providers.length && !providers.some((p) => p?.id === "youtube-captions")) {
 				store.set("lyrics.providers", [...providers, { id: "youtube-captions", enabled: true }]);
+			}
+		},
+	},
+	{
+		hook(store) {
+			const current = (store.store as SettingsStore)?.lyrics as (SettingsStore["lyrics"] & { showProgressBar?: unknown }) | undefined;
+			if (!current) return;
+			// `showProgressBar` (bool) became `lineStyle`. The old default drew a constant-rate text fill
+			// that drifted from the vocal, so everyone lands on the new "highlight" default rather than
+			// mapping true → fill.
+			if ("showProgressBar" in current) store.delete("lyrics.showProgressBar" as keyof SettingsStore);
+			if (current.lineStyle !== "highlight" && current.lineStyle !== "bar" && current.lineStyle !== "fill") {
+				store.set("lyrics.lineStyle", "highlight");
 			}
 		},
 	},

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
@@ -7,6 +7,7 @@ import { createYmlStore } from "@main/lib/store/createYmlStore";
 import type { ThemesConfig } from "@main/trpc/routers/themes/types";
 import { trackService } from "@main/trpc/routers/track";
 import eventNames from "@shared/constants/eventNames";
+import { DEFAULT_LYRICS_OVERLAY_SETTINGS, type LyricsOverlaySettings } from "@shared/lyrics/overlay";
 import { VideoResSetting } from "@shared/utils/ISettings";
 import { App, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import { Migration } from "electron-conf";
@@ -61,6 +62,8 @@ const defaultSettings = {
 		autoOpenTab: true,
 		/** Keep trying later providers for word/syllable cues before settling for line sync. */
 		preferWordSync: true,
+		/** Always-on-top transparent desktop lyrics window (see `@shared/lyrics/overlay`). */
+		overlay: { ...DEFAULT_LYRICS_OVERLAY_SETTINGS } as LyricsOverlaySettings,
 	},
 	player: {
 		skipDisliked: false,

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
@@ -45,7 +45,8 @@ const defaultSettings = {
 		enabled: false,
 		showTimeCodes: false,
 		showEvenIfInexact: true,
-		showProgressBar: true,
+		/** Progress indicator for line-only lyrics: highlight (none), bar (row background), fill (text colour). */
+		lineStyle: "highlight" as "highlight" | "bar" | "fill",
 		dynamicLyrics: true,
 		providers: [
 			{ id: "better-lyrics", enabled: true },

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
@@ -55,6 +55,10 @@ const defaultSettings = {
 		] as Array<{ id: "better-lyrics" | "unison" | "lrclib" | "youtube-captions"; enabled: boolean }>,
 		/** Optional Better Lyrics `X-API-Key`; empty = cached songs only. */
 		betterLyricsApiKey: "",
+		/** Switch the player page to the Lyrics tab when lyrics for a new track are showing. */
+		autoOpenTab: true,
+		/** Keep trying later providers for word/syllable cues before settling for line sync. */
+		preferWordSync: true,
 	},
 	player: {
 		skipDisliked: false,

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
@@ -45,9 +45,10 @@ const defaultSettings = {
 		enabled: false,
 		showTimeCodes: false,
 		showEvenIfInexact: true,
-		/** Progress indicator for line-only lyrics: highlight (none), bar (row background), fill (text colour). */
-		lineStyle: "highlight" as "highlight" | "bar" | "fill",
-		dynamicLyrics: true,
+		/** Tint the row behind the active line; off = text brightens only. */
+		lineBackground: true,
+		/** Active-line progress: highlight (none), bar (line-only row background), fill (word-synced sweep). */
+		lineStyle: "fill" as "highlight" | "bar" | "fill",
 		providers: [
 			{ id: "better-lyrics", enabled: true },
 			{ id: "unison", enabled: true },

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
@@ -51,7 +51,10 @@ const defaultSettings = {
 			{ id: "better-lyrics", enabled: true },
 			{ id: "unison", enabled: true },
 			{ id: "lrclib", enabled: true },
-		] as Array<{ id: "better-lyrics" | "unison" | "lrclib"; enabled: boolean }>,
+			{ id: "youtube-captions", enabled: true },
+		] as Array<{ id: "better-lyrics" | "unison" | "lrclib" | "youtube-captions"; enabled: boolean }>,
+		/** Optional Better Lyrics `X-API-Key`; empty = cached songs only. */
+		betterLyricsApiKey: "",
 	},
 	player: {
 		skipDisliked: false,

--- a/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/settings/service.ts
@@ -46,6 +46,7 @@ const defaultSettings = {
 		showTimeCodes: false,
 		showEvenIfInexact: true,
 		showProgressBar: true,
+		dynamicLyrics: true,
 		providers: [
 			{ id: "better-lyrics", enabled: true },
 			{ id: "unison", enabled: true },

--- a/apps/ytmdesktop2/src/main/trpc/routers/tray/service.ts
+++ b/apps/ytmdesktop2/src/main/trpc/routers/tray/service.ts
@@ -26,7 +26,19 @@ export default class TrayProvider extends BaseProvider implements AfterInit, OnD
 		if (!this._settingsBound) {
 			this._settingsBound = true;
 			this.settingsInstance.onSettingChange(
-				["app.autostart", "app.autoupdate", "app.minimizeTrayOverride", "discord.enabled", "discord.buttons", "themes.enabled", "themes.customFile", "themes.selected"],
+				[
+					"app.autostart",
+					"app.autoupdate",
+					"app.minimizeTrayOverride",
+					"discord.enabled",
+					"discord.buttons",
+					"themes.enabled",
+					"themes.customFile",
+					"themes.selected",
+					"lyrics.enabled",
+					"lyrics.overlay.enabled",
+					"lyrics.overlay.locked",
+				],
 				() => this.onSettingsChange(),
 				{ debounce: 50 },
 			);

--- a/apps/ytmdesktop2/src/main/windows/windowUtils.ts
+++ b/apps/ytmdesktop2/src/main/windows/windowUtils.ts
@@ -28,6 +28,12 @@ export type WindowOptions = {
 	type?: Electron.BrowserWindowConstructorOptions["type"];
 	/** Open detached DevTools (defaults to true in development). */
 	devtools?: boolean;
+	/** Transparent frameless window (no background colour / shadow) — desktop overlays. */
+	transparent?: boolean;
+	/** Native resize borders (default true). */
+	resizable?: boolean;
+	/** Extra BrowserWindow options merged last (alwaysOnTop, focusable, …). */
+	extraOptions?: Electron.BrowserWindowConstructorOptions;
 };
 const log = createLogger("main");
 export function parseScriptPath(p: string) {
@@ -258,8 +264,26 @@ export function shortcutOnWindow(
 
 export async function createAppWindow(appOptions?: Partial<WindowOptions>) {
 	// eslint-disable-next-line prefer-const
-	let { parent, path, minHeight, minWidth, maxHeight, maxWidth, height, width, top, showTaskBar, minimizeable, maximizeable, show, type, devtools } =
-		appOptions ?? {};
+	let {
+		parent,
+		path,
+		minHeight,
+		minWidth,
+		maxHeight,
+		maxWidth,
+		height,
+		width,
+		top,
+		showTaskBar,
+		minimizeable,
+		maximizeable,
+		show,
+		type,
+		devtools,
+		transparent,
+		resizable,
+		extraOptions,
+	} = appOptions ?? {};
 	if (!path) path = "/";
 	const shouldShow = show ?? true;
 	const shouldOpenDevtools = devtools ?? (isDevelopment || isProdDebug);
@@ -274,7 +298,9 @@ export async function createAppWindow(appOptions?: Partial<WindowOptions>) {
 		show: false,
 		minimizable: minimizeable === true,
 		maximizable: maximizeable === true,
-		backgroundColor: "#000000",
+		// Transparent windows must not paint an opaque backdrop.
+		...(transparent ? { transparent: true, hasShadow: false } : { backgroundColor: "#000000" }),
+		resizable: resizable !== false,
 		fullscreenable: !maxWidth && !maxHeight,
 		icon: appIconPath,
 		frame: false,
@@ -283,6 +309,7 @@ export async function createAppWindow(appOptions?: Partial<WindowOptions>) {
 		skipTaskbar: showTaskBar === false,
 		darkTheme: true,
 		...(type ? { type } : {}),
+		...extraOptions,
 		webPreferences: {
 			// Use pluginOptions.nodeIntegration, leave this alone
 			// See nklayman.github.io/vue-cli-plugin-electron-builder/guide/security.html#node-integration for more info
@@ -290,6 +317,7 @@ export async function createAppWindow(appOptions?: Partial<WindowOptions>) {
 			contextIsolation: true,
 			sandbox: false,
 			preload: join(__dirname, "../preload/api.js"),
+			...extraOptions?.webPreferences,
 		},
 	});
 

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.page.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.page.ts
@@ -128,6 +128,17 @@ function readCurrentTimeSec(): number {
 	}
 }
 
+/** YT player state 1 = playing (2 paused, 3 buffering, 5 cued). */
+function readIsPlaying(): boolean {
+	const api = getPagePlayerApi();
+	if (!api || typeof api.getPlayerState !== "function") return false;
+	try {
+		return Number(api.getPlayerState()) === 1;
+	} catch {
+		return false;
+	}
+}
+
 function seekToSec(timeSec: number): boolean {
 	const api = getPagePlayerApi();
 	if (!api || typeof api.seekTo !== "function") return false;
@@ -223,6 +234,7 @@ type LyricsTickMessage = {
 	type: string;
 	kind: "tick";
 	timeSec: number;
+	playing: boolean;
 };
 
 let clockWanted = false;
@@ -234,6 +246,7 @@ function emitTimeTick(): void {
 		type: LYRICS_BRIDGE_TYPE,
 		kind: "tick",
 		timeSec: readCurrentTimeSec(),
+		playing: readIsPlaying(),
 	};
 	window.postMessage(msg, "*");
 }
@@ -297,10 +310,10 @@ function isLyricsTick(data: unknown): data is LyricsTickMessage {
 }
 
 /** Preload: subscribe to page-world playback ticks (smooth progress / no bridge request storm). */
-export function subscribeLyricsTime(handler: (timeSec: number) => void): () => void {
+export function subscribeLyricsTime(handler: (timeSec: number, playing: boolean) => void): () => void {
 	const onMessage = (ev: MessageEvent) => {
 		if (!isLyricsTick(ev.data)) return;
-		handler(ev.data.timeSec);
+		handler(ev.data.timeSec, ev.data.playing === true);
 	};
 	window.addEventListener("message", onMessage);
 	return () => window.removeEventListener("message", onMessage);

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.page.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.page.ts
@@ -1,7 +1,7 @@
 import { definePageCmds } from "@plugins/define-bridge";
-import type { TrackSearchInfo } from "./lyrics/types";
-import { resolveYtmStore } from "./ytm-store";
+import type { TrackSearchInfo, YouTubeCaptionTrack, YouTubeCaptionTracks } from "./lyrics/types";
 import { getPagePlayerApi } from "./world0/context";
+import { resolveYtmStore } from "./ytm-store";
 
 function readAlbumTitle(): string | undefined {
 	try {
@@ -60,6 +60,62 @@ export function readTrackInfoFromPlayer(): TrackSearchInfo | null {
 		musicVideoType: String(details?.musicVideoType || micro?.musicVideoType || ""),
 		isLiveContent: !!details?.isLiveContent,
 	};
+}
+
+function captionName(name: unknown): string {
+	if (typeof name === "string") return name;
+	const obj = name as { simpleText?: unknown; runs?: { text?: unknown }[] } | null;
+	if (typeof obj?.simpleText === "string") return obj.simpleText;
+	if (Array.isArray(obj?.runs)) return obj.runs.map((r) => String(r?.text ?? "")).join("");
+	return "";
+}
+
+/**
+ * Caption tracks for the *current* player video.
+ * Prefers `getPlayerResponse().captions` (documented shape); falls back to `getAudioTrack().captionTracks`.
+ */
+export function readCaptionTracksFromPlayer(): YouTubeCaptionTracks | null {
+	const api = getPagePlayerApi();
+	if (!api) return null;
+
+	let videoId = "";
+	const tracks: YouTubeCaptionTrack[] = [];
+	const push = (raw: Record<string, unknown> | null | undefined) => {
+		const url = raw?.baseUrl ?? raw?.url;
+		const languageCode = raw?.languageCode;
+		if (typeof url !== "string" || !url || typeof languageCode !== "string") return;
+		tracks.push({
+			languageCode,
+			url,
+			isAuto: raw?.kind === "asr" || String(raw?.vssId ?? "").startsWith("a."),
+			name: captionName(raw?.name ?? raw?.displayName),
+		});
+	};
+
+	try {
+		const response = api.getPlayerResponse?.() as
+			| {
+					videoDetails?: { videoId?: unknown };
+					captions?: { playerCaptionsTracklistRenderer?: { captionTracks?: Record<string, unknown>[] } };
+			  }
+			| undefined;
+		videoId = String(response?.videoDetails?.videoId ?? "");
+		for (const raw of response?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? []) push(raw);
+	} catch {
+		/* mid-nav */
+	}
+
+	if (!tracks.length) {
+		try {
+			const audio = api.getAudioTrack?.() as { captionTracks?: Record<string, unknown>[] } | undefined;
+			for (const raw of audio?.captionTracks ?? []) push(raw);
+		} catch {
+			/* ignore */
+		}
+	}
+	if (!videoId) videoId = readTrackInfoFromPlayer()?.videoId ?? "";
+	if (!videoId) return null;
+	return { videoId, tracks };
 }
 
 function readCurrentTimeSec(): number {
@@ -220,6 +276,7 @@ export const lyricsPage = definePageCmds({
 	cmds: {
 		trackInfo: () => readTrackInfoFromPlayer(),
 		nextTrackInfo: () => readNextTrackInfoFromQueue(),
+		captionTracks: () => readCaptionTracksFromPlayer(),
 		currentTime: () => readCurrentTimeSec(),
 		seek: (timeSec) => seekToSec(Number(timeSec) || 0),
 		startClock: () => startLyricsClock(),

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
@@ -63,6 +63,15 @@ function readLyricsSettings(settings?: Record<string, any>) {
 		showProgressBar: s?.lyrics?.showProgressBar !== false,
 		dynamicLyrics: s?.lyrics?.dynamicLyrics !== false,
 		providers: s?.lyrics?.providers,
+		betterLyricsApiKey: typeof s?.lyrics?.betterLyricsApiKey === "string" ? s.lyrics.betterLyricsApiKey : "",
+	};
+}
+
+function fetchOptions(cfg: ReturnType<typeof readLyricsSettings>) {
+	return {
+		showEvenIfInexact: cfg.showEvenIfInexact,
+		providers: cfg.providers,
+		betterLyricsApiKey: cfg.betterLyricsApiKey,
 	};
 }
 
@@ -80,10 +89,7 @@ async function prefetchNextTrack(cfg: ReturnType<typeof readLyricsSettings>) {
 	try {
 		const next = await lyricsPage.request("nextTrackInfo");
 		if (!canPrefetchTrack(next)) return;
-		runtime.store.prefetchForTrack(next, {
-			showEvenIfInexact: cfg.showEvenIfInexact,
-			providers: cfg.providers,
-		});
+		runtime.store.prefetchForTrack(next, fetchOptions(cfg));
 		runtime.log?.debug("lyrics: prefetch next", next.videoId, next.title);
 	} catch (err) {
 		runtime.log?.debug("lyrics: prefetch next failed", err);
@@ -109,10 +115,7 @@ async function refreshTrack(expectVideoId?: string | null) {
 	}
 	runtime.lastVideoId = info.videoId;
 	const cfg = readLyricsSettings();
-	await runtime.store.fetchForTrack(info, {
-		showEvenIfInexact: cfg.showEvenIfInexact,
-		providers: cfg.providers,
-	});
+	await runtime.store.fetchForTrack(info, fetchOptions(cfg));
 	if (!runtime.active) return;
 	if (runtime.lastVideoId !== info.videoId) return;
 	void prefetchNextTrack(cfg);
@@ -201,7 +204,11 @@ async function startLyrics() {
 			if (key === "lyrics.showTimeCodes" || key === "lyrics.showProgressBar" || key === "lyrics.dynamicLyrics") {
 				runtime.renderer?.repaint();
 			}
-			if (key === "lyrics.showEvenIfInexact" || key === "lyrics.providers") {
+			if (
+				key === "lyrics.showEvenIfInexact" ||
+				key === "lyrics.providers" ||
+				key === "lyrics.betterLyricsApiKey"
+			) {
 				runtime.store.clearCache();
 				void refreshTrack();
 			}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
@@ -64,8 +64,8 @@ function readLyricsSettings(settings?: Record<string, any>) {
 		enabled: !!s?.lyrics?.enabled,
 		showTimeCodes: !!s?.lyrics?.showTimeCodes,
 		showEvenIfInexact: s?.lyrics?.showEvenIfInexact !== false,
+		lineBackground: s?.lyrics?.lineBackground !== false,
 		lineStyle: readLineStyle(s?.lyrics?.lineStyle),
-		dynamicLyrics: s?.lyrics?.dynamicLyrics !== false,
 		providers: s?.lyrics?.providers,
 		betterLyricsApiKey: typeof s?.lyrics?.betterLyricsApiKey === "string" ? s.lyrics.betterLyricsApiKey : "",
 		autoOpenTab: s?.lyrics?.autoOpenTab !== false,
@@ -209,8 +209,8 @@ async function startLyrics() {
 
 	runtime.renderer = createLyricsRenderer(() => runtime.mount?.getHost() ?? null, {
 		showTimeCodes: () => readLyricsSettings().showTimeCodes,
+		lineBackground: () => readLyricsSettings().lineBackground,
 		lineStyle: () => readLyricsSettings().lineStyle,
-		dynamicLyrics: () => readLyricsSettings().dynamicLyrics,
 		onSeek: (timeMs) => {
 			void seekPlayer((timeMs + SEEK_OFFSET_MS) / 1000).then((ok) => {
 				if (!ok) runtime.log?.debug("lyrics: seek failed");
@@ -224,7 +224,7 @@ async function startLyrics() {
 	});
 	runtime.unsubSettings =
 		runtime.onSettingsChange?.((key) => {
-			if (key === "lyrics.showTimeCodes" || key === "lyrics.lineStyle" || key === "lyrics.dynamicLyrics") {
+			if (key === "lyrics.showTimeCodes" || key === "lyrics.lineBackground" || key === "lyrics.lineStyle") {
 				runtime.renderer?.repaint();
 			}
 			if (

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
@@ -1,7 +1,7 @@
 import definePlugin from "@plugins/utils";
 import { getYtmd } from "@preload/preload-local";
 import { createLyricsStore } from "./lyrics/store";
-import { createTabMount, type TabMountHandle } from "./lyrics/tab-mount";
+import { createTabMount, selectLyricsTab, type TabMountHandle } from "./lyrics/tab-mount";
 import {
 	seekPlayer,
 	shouldSkipTrack,
@@ -35,6 +35,8 @@ interface LyricsRuntime {
 	tabSelected: boolean;
 	started: boolean;
 	lastVideoId: string | null;
+	/** videoId the Lyrics tab was auto-opened for (once per track). */
+	autoOpenedFor: string | null;
 }
 
 const runtime: LyricsRuntime = {
@@ -52,6 +54,7 @@ const runtime: LyricsRuntime = {
 	tabSelected: false,
 	started: false,
 	lastVideoId: null,
+	autoOpenedFor: null,
 };
 
 function readLyricsSettings(settings?: Record<string, any>) {
@@ -64,6 +67,8 @@ function readLyricsSettings(settings?: Record<string, any>) {
 		dynamicLyrics: s?.lyrics?.dynamicLyrics !== false,
 		providers: s?.lyrics?.providers,
 		betterLyricsApiKey: typeof s?.lyrics?.betterLyricsApiKey === "string" ? s.lyrics.betterLyricsApiKey : "",
+		autoOpenTab: s?.lyrics?.autoOpenTab !== false,
+		preferWordSync: s?.lyrics?.preferWordSync !== false,
 	};
 }
 
@@ -72,6 +77,7 @@ function fetchOptions(cfg: ReturnType<typeof readLyricsSettings>) {
 		showEvenIfInexact: cfg.showEvenIfInexact,
 		providers: cfg.providers,
 		betterLyricsApiKey: cfg.betterLyricsApiKey,
+		preferWordSync: cfg.preferWordSync,
 	};
 }
 
@@ -119,6 +125,19 @@ async function refreshTrack(expectVideoId?: string | null) {
 	if (!runtime.active) return;
 	if (runtime.lastVideoId !== info.videoId) return;
 	void prefetchNextTrack(cfg);
+}
+
+/**
+ * With `autoOpenTab`, switch the player page to the Lyrics tab once lyrics for a new track are showing
+ * (our overlay or stock YTM). Once per videoId, so a manual switch away is respected for that track.
+ */
+function maybeAutoOpenTab(snap: { status: string; videoId: string | null }) {
+	if (!runtime.active || !snap.videoId) return;
+	if (snap.status !== "ready" && snap.status !== "stock") return;
+	if (runtime.autoOpenedFor === snap.videoId) return;
+	runtime.autoOpenedFor = snap.videoId;
+	if (!readLyricsSettings().autoOpenTab) return;
+	if (!selectLyricsTab()) runtime.log?.debug("lyrics: auto-open tab skipped (header missing/disabled)");
 }
 
 function applyTickTime(timeSec: number) {
@@ -198,7 +217,10 @@ async function startLyrics() {
 		},
 	});
 
-	runtime.unsubStore = runtime.store.subscribe((snap) => runtime.renderer?.setSnapshot(snap));
+	runtime.unsubStore = runtime.store.subscribe((snap) => {
+		runtime.renderer?.setSnapshot(snap);
+		maybeAutoOpenTab(snap);
+	});
 	runtime.unsubSettings =
 		runtime.onSettingsChange?.((key) => {
 			if (key === "lyrics.showTimeCodes" || key === "lyrics.showProgressBar" || key === "lyrics.dynamicLyrics") {
@@ -207,7 +229,8 @@ async function startLyrics() {
 			if (
 				key === "lyrics.showEvenIfInexact" ||
 				key === "lyrics.providers" ||
-				key === "lyrics.betterLyricsApiKey"
+				key === "lyrics.betterLyricsApiKey" ||
+				key === "lyrics.preferWordSync"
 			) {
 				runtime.store.clearCache();
 				void refreshTrack();
@@ -226,6 +249,7 @@ function stopLyrics() {
 	runtime.active = false;
 	runtime.tabSelected = false;
 	runtime.lastVideoId = null;
+	runtime.autoOpenedFor = null;
 	stopTimePoll();
 	unbindTrackWatch();
 	runtime.unsubStore?.();

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
@@ -1,6 +1,8 @@
 import definePlugin from "@plugins/utils";
 import { getYtmd } from "@preload/preload-local";
+import { LYRICS_OVERLAY_IPC, readLyricsOverlaySettings } from "@shared/lyrics/overlay";
 import { readLineStyle } from "./lyrics/line-style";
+import { createOverlayPublisher, type OverlayPublisher, toOverlaySnapshot } from "./lyrics/overlay-publisher";
 import { createLyricsStore } from "./lyrics/store";
 import { createTabMount, selectLyricsTab, type TabMountHandle } from "./lyrics/tab-mount";
 import {
@@ -23,6 +25,8 @@ type LyricsLogger = { debug: (...args: unknown[]) => void; error: (...args: unkn
 
 interface LyricsRuntime {
 	store: ReturnType<typeof createLyricsStore>;
+	/** Desktop overlay feed (main process relays to the `/lyrics-overlay` window). */
+	overlay: OverlayPublisher;
 	mount: TabMountHandle | null;
 	renderer: LyricsRenderApi | null;
 	unsubStore: (() => void) | null;
@@ -40,8 +44,20 @@ interface LyricsRuntime {
 	autoOpenedFor: string | null;
 }
 
+function sendToMain(channel: string, payload: unknown) {
+	try {
+		getYtmd().sendInternal(channel, payload);
+	} catch (err) {
+		runtime.log?.debug("lyrics: overlay send failed", channel, err);
+	}
+}
+
 const runtime: LyricsRuntime = {
 	store: createLyricsStore(),
+	overlay: createOverlayPublisher({
+		sendSnapshot: (snap) => sendToMain(LYRICS_OVERLAY_IPC.snapshot, snap),
+		sendClock: (clock) => sendToMain(LYRICS_OVERLAY_IPC.clock, clock),
+	}),
 	mount: null,
 	renderer: null,
 	unsubStore: null,
@@ -70,6 +86,7 @@ function readLyricsSettings(settings?: Record<string, any>) {
 		betterLyricsApiKey: typeof s?.lyrics?.betterLyricsApiKey === "string" ? s.lyrics.betterLyricsApiKey : "",
 		autoOpenTab: s?.lyrics?.autoOpenTab !== false,
 		preferWordSync: s?.lyrics?.preferWordSync !== false,
+		overlayEnabled: readLyricsOverlaySettings(s?.lyrics?.overlay).enabled,
 	};
 }
 
@@ -141,9 +158,11 @@ function maybeAutoOpenTab(snap: { status: string; videoId: string | null }) {
 	if (!selectLyricsTab()) runtime.log?.debug("lyrics: auto-open tab skipped (header missing/disabled)");
 }
 
-function applyTickTime(timeSec: number) {
-	if (!runtime.renderer || !runtime.active || !runtime.tabSelected) return;
-	runtime.renderer.setTime(timeSec * 1000 + DISPLAY_LEAD_MS);
+function applyTickTime(timeSec: number, playing: boolean) {
+	if (!runtime.active) return;
+	const timeMs = timeSec * 1000 + DISPLAY_LEAD_MS;
+	if (runtime.renderer && runtime.tabSelected) runtime.renderer.setTime(timeMs);
+	runtime.overlay.tick(timeMs, playing);
 }
 
 async function startTimePoll() {
@@ -161,6 +180,14 @@ function stopTimePoll() {
 	stopLyricsClock();
 	runtime.unsubTime?.();
 	runtime.unsubTime = null;
+	runtime.overlay.resetClock();
+}
+
+/** The page clock runs while anything consumes it: the Lyrics tab or the desktop overlay. */
+function syncTimePoll() {
+	if (!runtime.active) return;
+	if (runtime.tabSelected || runtime.overlay.isEnabled()) void startTimePoll();
+	else stopTimePoll();
 }
 
 function unbindTrackWatch() {
@@ -198,14 +225,11 @@ async function startLyrics() {
 		},
 		onTabSelectedChange: (selected) => {
 			runtime.tabSelected = selected;
-			if (selected) {
-				void startTimePoll();
-			} else {
-				stopTimePoll();
-			}
+			syncTimePoll();
 		},
 	});
 	runtime.tabSelected = runtime.mount.isLyricsTabSelected();
+	runtime.overlay.setEnabled(readLyricsSettings().overlayEnabled);
 
 	runtime.renderer = createLyricsRenderer(() => runtime.mount?.getHost() ?? null, {
 		showTimeCodes: () => readLyricsSettings().showTimeCodes,
@@ -220,12 +244,17 @@ async function startLyrics() {
 
 	runtime.unsubStore = runtime.store.subscribe((snap) => {
 		runtime.renderer?.setSnapshot(snap);
+		runtime.overlay.setSnapshot(toOverlaySnapshot(snap, true));
 		maybeAutoOpenTab(snap);
 	});
 	runtime.unsubSettings =
 		runtime.onSettingsChange?.((key) => {
 			if (key === "lyrics.showTimeCodes" || key === "lyrics.lineBackground" || key === "lyrics.lineStyle") {
 				runtime.renderer?.repaint();
+			}
+			if (key === "lyrics.overlay.enabled") {
+				runtime.overlay.setEnabled(readLyricsSettings().overlayEnabled);
+				syncTimePoll();
 			}
 			if (
 				key === "lyrics.showEvenIfInexact" ||
@@ -239,7 +268,7 @@ async function startLyrics() {
 		}) ?? null;
 
 	bindTrackWatch();
-	if (runtime.tabSelected) await startTimePoll();
+	if (runtime.tabSelected || runtime.overlay.isEnabled()) await startTimePoll();
 	await refreshTrack();
 	runtime.renderer.repaint();
 }
@@ -247,6 +276,8 @@ async function startLyrics() {
 function stopLyrics() {
 	if (!runtime.active && !runtime.mount) return;
 	runtime.log?.debug("lyrics: stop");
+	// Tell the overlay (if open) that lyrics are off rather than leaving the last song frozen on screen.
+	runtime.overlay.setSnapshot(toOverlaySnapshot(runtime.store.getSnapshot(), false));
 	runtime.active = false;
 	runtime.tabSelected = false;
 	runtime.lastVideoId = null;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
@@ -9,10 +9,10 @@ import {
 	stopLyricsClock,
 	trackInfoFromMainWorld,
 } from "./lyrics/track";
+import type { TrackSearchInfo } from "./lyrics/types";
 import { createLyricsRenderer, type LyricsRenderApi } from "./lyrics/ui/render";
 import { lyricsPage, subscribeLyricsTime } from "./lyrics.page";
 import lyricsRenderer from "./lyrics.renderer";
-import type { TrackSearchInfo } from "./lyrics/types";
 
 const SEEK_OFFSET_MS = 10;
 /** Nudge UI ahead of getCurrentTime - YTM clock often trails audible audio. */
@@ -61,6 +61,7 @@ function readLyricsSettings(settings?: Record<string, any>) {
 		showTimeCodes: !!s?.lyrics?.showTimeCodes,
 		showEvenIfInexact: s?.lyrics?.showEvenIfInexact !== false,
 		showProgressBar: s?.lyrics?.showProgressBar !== false,
+		dynamicLyrics: s?.lyrics?.dynamicLyrics !== false,
 		providers: s?.lyrics?.providers,
 	};
 }
@@ -186,6 +187,7 @@ async function startLyrics() {
 	runtime.renderer = createLyricsRenderer(() => runtime.mount?.getHost() ?? null, {
 		showTimeCodes: () => readLyricsSettings().showTimeCodes,
 		showProgressBar: () => readLyricsSettings().showProgressBar,
+		dynamicLyrics: () => readLyricsSettings().dynamicLyrics,
 		onSeek: (timeMs) => {
 			void seekPlayer((timeMs + SEEK_OFFSET_MS) / 1000).then((ok) => {
 				if (!ok) runtime.log?.debug("lyrics: seek failed");
@@ -196,7 +198,7 @@ async function startLyrics() {
 	runtime.unsubStore = runtime.store.subscribe((snap) => runtime.renderer?.setSnapshot(snap));
 	runtime.unsubSettings =
 		runtime.onSettingsChange?.((key) => {
-			if (key === "lyrics.showTimeCodes" || key === "lyrics.showProgressBar") {
+			if (key === "lyrics.showTimeCodes" || key === "lyrics.showProgressBar" || key === "lyrics.dynamicLyrics") {
 				runtime.renderer?.repaint();
 			}
 			if (key === "lyrics.showEvenIfInexact" || key === "lyrics.providers") {

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics.plugin.ts
@@ -1,5 +1,6 @@
 import definePlugin from "@plugins/utils";
 import { getYtmd } from "@preload/preload-local";
+import { readLineStyle } from "./lyrics/line-style";
 import { createLyricsStore } from "./lyrics/store";
 import { createTabMount, selectLyricsTab, type TabMountHandle } from "./lyrics/tab-mount";
 import {
@@ -63,7 +64,7 @@ function readLyricsSettings(settings?: Record<string, any>) {
 		enabled: !!s?.lyrics?.enabled,
 		showTimeCodes: !!s?.lyrics?.showTimeCodes,
 		showEvenIfInexact: s?.lyrics?.showEvenIfInexact !== false,
-		showProgressBar: s?.lyrics?.showProgressBar !== false,
+		lineStyle: readLineStyle(s?.lyrics?.lineStyle),
 		dynamicLyrics: s?.lyrics?.dynamicLyrics !== false,
 		providers: s?.lyrics?.providers,
 		betterLyricsApiKey: typeof s?.lyrics?.betterLyricsApiKey === "string" ? s.lyrics.betterLyricsApiKey : "",
@@ -208,7 +209,7 @@ async function startLyrics() {
 
 	runtime.renderer = createLyricsRenderer(() => runtime.mount?.getHost() ?? null, {
 		showTimeCodes: () => readLyricsSettings().showTimeCodes,
-		showProgressBar: () => readLyricsSettings().showProgressBar,
+		lineStyle: () => readLyricsSettings().lineStyle,
 		dynamicLyrics: () => readLyricsSettings().dynamicLyrics,
 		onSeek: (timeMs) => {
 			void seekPlayer((timeMs + SEEK_OFFSET_MS) / 1000).then((ok) => {
@@ -223,7 +224,7 @@ async function startLyrics() {
 	});
 	runtime.unsubSettings =
 		runtime.onSettingsChange?.((key) => {
-			if (key === "lyrics.showTimeCodes" || key === "lyrics.showProgressBar" || key === "lyrics.dynamicLyrics") {
+			if (key === "lyrics.showTimeCodes" || key === "lyrics.lineStyle" || key === "lyrics.dynamicLyrics") {
 				runtime.renderer?.repaint();
 			}
 			if (

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/line-style.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/line-style.ts
@@ -1,0 +1,13 @@
+/**
+ * How the active line shows progress when the provider only has line timing (no word/syllable cues).
+ * - `highlight`: light the line up (and enlarge it with Dynamic lyrics) — no progress indicator.
+ * - `bar`: row background that advances with playback.
+ * - `fill`: text colour that advances with playback (constant rate — drifts from the vocal).
+ */
+export type LyricsLineStyle = "highlight" | "bar" | "fill";
+
+export const DEFAULT_LINE_STYLE: LyricsLineStyle = "highlight";
+
+export function readLineStyle(value: unknown): LyricsLineStyle {
+	return value === "bar" || value === "fill" ? value : DEFAULT_LINE_STYLE;
+}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/line-style.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/line-style.ts
@@ -1,12 +1,14 @@
 /**
- * How the active line shows progress when the provider only has line timing (no word/syllable cues).
- * - `highlight`: light the line up (and enlarge it with Dynamic lyrics) — no progress indicator.
- * - `bar`: row background that advances with playback.
- * - `fill`: text colour that advances with playback (constant rate — drifts from the vocal).
+ * How the active line shows progress.
+ * - `highlight`: light the line up; word/syllable cues step word by word — no extra indicator.
+ * - `bar`: line-only cues get a row background that advances with playback (constant rate — line
+ *   timing has no per-word pacing). Word-synced lines behave like `highlight`.
+ * - `fill`: word/syllable cues sweep each word's colour left → right over its duration. Line-only
+ *   cues fall back to `highlight`, since a constant-rate fill would only guess where the vocal is.
  */
 export type LyricsLineStyle = "highlight" | "bar" | "fill";
 
-export const DEFAULT_LINE_STYLE: LyricsLineStyle = "highlight";
+export const DEFAULT_LINE_STYLE: LyricsLineStyle = "fill";
 
 export function readLineStyle(value: unknown): LyricsLineStyle {
 	return value === "bar" || value === "fill" ? value : DEFAULT_LINE_STYLE;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/overlay-publisher.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/overlay-publisher.test.ts
@@ -1,0 +1,120 @@
+import type { LyricsOverlayClock, LyricsOverlaySnapshot } from "@shared/lyrics/overlay";
+import { describe, expect, it } from "vitest";
+import {
+	createOverlayPublisher,
+	OVERLAY_CLOCK_DRIFT_MS,
+	OVERLAY_CLOCK_HEARTBEAT_MS,
+	toOverlaySnapshot,
+} from "./overlay-publisher";
+import type { LyricsStoreSnapshot } from "./store";
+import type { LyricResult } from "./types";
+
+const result: LyricResult = {
+	title: "Song",
+	artists: ["Artist"],
+	provider: "lrclib",
+	lines: [
+		{ timeMs: 0, text: "one", durationMs: 1000 },
+		{ timeMs: 1000, text: "two", durationMs: 1000 },
+	],
+};
+
+function harness() {
+	const snapshots: LyricsOverlaySnapshot[] = [];
+	const clocks: LyricsOverlayClock[] = [];
+	let now = 1_000;
+	const publisher = createOverlayPublisher(
+		{ sendSnapshot: (s) => snapshots.push(s), sendClock: (c) => clocks.push(c) },
+		() => now,
+	);
+	return { publisher, snapshots, clocks, advance: (ms: number) => (now += ms) };
+}
+
+describe("toOverlaySnapshot", () => {
+	it("maps timed results to ready, plain results to plain, misses to empty", () => {
+		const base: LyricsStoreSnapshot = { status: "ready", result, videoId: "v1" };
+		expect(toOverlaySnapshot(base, true)).toMatchObject({ status: "ready", videoId: "v1", title: "Song", artists: ["Artist"] });
+		expect(toOverlaySnapshot(base, true).lines).toBe(result.lines);
+		expect(toOverlaySnapshot({ ...base, result: { ...result, lines: undefined, plain: "text" } }, true).status).toBe("plain");
+		expect(toOverlaySnapshot({ status: "empty", result: null, videoId: "v1" }, true).status).toBe("empty");
+		expect(toOverlaySnapshot({ status: "error", result: null, videoId: "v1", errorMessage: "x" }, true).status).toBe("empty");
+		expect(toOverlaySnapshot({ status: "loading", result: null, videoId: "v1" }, true).status).toBe("loading");
+	});
+
+	it("reports disabled regardless of store state when the plugin is off", () => {
+		expect(toOverlaySnapshot({ status: "ready", result, videoId: "v1" }, false)).toMatchObject({ status: "disabled", lines: null });
+	});
+});
+
+describe("createOverlayPublisher", () => {
+	it("holds snapshots while disabled and replays the latest one on enable", () => {
+		const { publisher, snapshots } = harness();
+		publisher.setSnapshot(toOverlaySnapshot({ status: "loading", result: null, videoId: "v1" }, true));
+		publisher.setSnapshot(toOverlaySnapshot({ status: "ready", result, videoId: "v1" }, true));
+		expect(snapshots).toHaveLength(0);
+		publisher.setEnabled(true);
+		expect(snapshots).toHaveLength(1);
+		expect(snapshots[0].status).toBe("ready");
+	});
+
+	it("skips duplicate snapshots", () => {
+		const { publisher, snapshots } = harness();
+		publisher.setEnabled(true);
+		const snap = toOverlaySnapshot({ status: "ready", result, videoId: "v1" }, true);
+		publisher.setSnapshot(snap);
+		publisher.setSnapshot({ ...snap });
+		expect(snapshots).toHaveLength(1);
+	});
+
+	it("sends a clock on first tick, on play/pause, on drift and on the heartbeat only", () => {
+		const { publisher, clocks, advance } = harness();
+		publisher.tick(0, true);
+		expect(clocks).toHaveLength(0); // disabled → nothing
+
+		publisher.setEnabled(true);
+		publisher.tick(1000, true);
+		expect(clocks).toEqual([{ timeMs: 1000, playing: true, at: 1000 }]);
+
+		// Steady playback: extrapolation matches → silent.
+		advance(500);
+		publisher.tick(1500, true);
+		advance(500);
+		publisher.tick(2000 + OVERLAY_CLOCK_DRIFT_MS / 2, true);
+		expect(clocks).toHaveLength(1);
+
+		// Seek → drift beyond tolerance.
+		advance(100);
+		publisher.tick(30_000, true);
+		expect(clocks).toHaveLength(2);
+		expect(clocks[1]).toMatchObject({ timeMs: 30_000, playing: true });
+
+		// Pause → state change.
+		advance(200);
+		publisher.tick(30_200, false);
+		expect(clocks).toHaveLength(3);
+		expect(clocks[2].playing).toBe(false);
+
+		// Paused and still: silent until the heartbeat.
+		advance(OVERLAY_CLOCK_HEARTBEAT_MS - 1);
+		publisher.tick(30_200, false);
+		expect(clocks).toHaveLength(3);
+		advance(1);
+		publisher.tick(30_200, false);
+		expect(clocks).toHaveLength(4);
+	});
+
+	it("resends after resetClock and after a disable/enable cycle", () => {
+		const { publisher, clocks, advance } = harness();
+		publisher.setEnabled(true);
+		publisher.tick(0, true);
+		advance(16);
+		publisher.resetClock();
+		publisher.tick(16, true);
+		expect(clocks).toHaveLength(2);
+		publisher.setEnabled(false);
+		publisher.setEnabled(true);
+		advance(16);
+		publisher.tick(32, true);
+		expect(clocks).toHaveLength(3);
+	});
+});

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/overlay-publisher.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/overlay-publisher.ts
@@ -1,0 +1,101 @@
+import {
+	EMPTY_LYRICS_OVERLAY_SNAPSHOT,
+	type LyricsOverlayClock,
+	type LyricsOverlaySnapshot,
+} from "@shared/lyrics/overlay";
+import type { LyricsStoreSnapshot } from "./store";
+
+/** Resend the clock when the overlay's extrapolation would be off by more than this (seek / stall). */
+export const OVERLAY_CLOCK_DRIFT_MS = 90;
+/** Heartbeat so a missed packet self-heals and rate drift never accumulates. */
+export const OVERLAY_CLOCK_HEARTBEAT_MS = 1500;
+
+export interface OverlayPublisherTransport {
+	sendSnapshot(snap: LyricsOverlaySnapshot): void;
+	sendClock(clock: LyricsOverlayClock): void;
+}
+
+/** Map the in-tab lyrics store snapshot onto the (smaller) overlay contract. */
+export function toOverlaySnapshot(snap: LyricsStoreSnapshot, lyricsEnabled: boolean): LyricsOverlaySnapshot {
+	if (!lyricsEnabled) return { ...EMPTY_LYRICS_OVERLAY_SNAPSHOT, status: "disabled" };
+	const result = snap.result;
+	const base = {
+		videoId: snap.videoId,
+		title: result?.title ?? "",
+		artists: result?.artists ?? [],
+		hasWordSync: !!result?.hasWordSync,
+	};
+	switch (snap.status) {
+		case "loading":
+			return { ...base, status: "loading", lines: null };
+		case "ready":
+		case "stock": {
+			if (result?.lines?.length) return { ...base, status: "ready", lines: result.lines };
+			if (result?.plain) return { ...base, status: "plain", lines: null };
+			return { ...base, status: "empty", lines: null };
+		}
+		case "empty":
+		case "error":
+		case "skipped":
+			return { ...base, status: "empty", lines: null };
+		default:
+			return { ...base, status: "idle", lines: null };
+	}
+}
+
+function sameSnapshot(a: LyricsOverlaySnapshot | null, b: LyricsOverlaySnapshot): boolean {
+	if (!a) return false;
+	return a.status === b.status && a.videoId === b.videoId && a.lines === b.lines && a.title === b.title;
+}
+
+/**
+ * Publishes lyrics + a low-rate playback clock to the desktop overlay.
+ * Snapshots go out on change only; clock packets go out on play/pause, on drift (seek) and on a heartbeat,
+ * so the ~30 Hz page tick never becomes a ~30 Hz IPC stream.
+ */
+export function createOverlayPublisher(transport: OverlayPublisherTransport, now: () => number = () => Date.now()) {
+	let enabled = false;
+	let lastSnapshot: LyricsOverlaySnapshot | null = null;
+	let lastClock: LyricsOverlayClock | null = null;
+
+	const flushSnapshot = () => {
+		if (lastSnapshot) transport.sendSnapshot(lastSnapshot);
+	};
+
+	return {
+		isEnabled(): boolean {
+			return enabled;
+		},
+		/** Overlay open/closed. Enabling replays the last snapshot so a fresh window has content. */
+		setEnabled(next: boolean): void {
+			if (next === enabled) return;
+			enabled = next;
+			lastClock = null;
+			if (enabled) flushSnapshot();
+		},
+		setSnapshot(snap: LyricsOverlaySnapshot): void {
+			if (sameSnapshot(lastSnapshot, snap)) return;
+			lastSnapshot = snap;
+			if (enabled) transport.sendSnapshot(snap);
+		},
+		/** Playback tick from the page clock. `timeMs` should already include the display lead. */
+		tick(timeMs: number, playing: boolean): void {
+			if (!enabled) return;
+			const at = now();
+			let send = !lastClock || lastClock.playing !== playing;
+			if (!send && lastClock) {
+				const expected = lastClock.playing ? lastClock.timeMs + (at - lastClock.at) : lastClock.timeMs;
+				send = Math.abs(timeMs - expected) > OVERLAY_CLOCK_DRIFT_MS || at - lastClock.at >= OVERLAY_CLOCK_HEARTBEAT_MS;
+			}
+			if (!send) return;
+			lastClock = { timeMs, playing, at };
+			transport.sendClock(lastClock);
+		},
+		/** Force the next tick to resend (track change / clock restart). */
+		resetClock(): void {
+			lastClock = null;
+		},
+	};
+}
+
+export type OverlayPublisher = ReturnType<typeof createOverlayPublisher>;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/progress.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/progress.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { wordProgress } from "./progress";
+
+describe("wordProgress", () => {
+	const word = { text: "Hello", timeMs: 1000, durationMs: 2000 };
+
+	it("fills a sustained syllable and stays filled during the following gap", () => {
+		expect([500, 1000, 1500, 2000, 3000, 4000].map((time) => wordProgress(word, time))).toEqual([0, 0, 0.25, 0.5, 1, 1]);
+	});
+
+	it("follows playback time through pauses and backward seeks", () => {
+		expect([2500, 2500, 1500].map((time) => wordProgress(word, time))).toEqual([0.75, 0.75, 0.25]);
+	});
+
+	it("fills overlapping cues independently", () => {
+		expect(wordProgress(word, 2000)).toBe(0.5);
+		expect(wordProgress({ ...word, timeMs: 1500, durationMs: 2000 }, 2000)).toBe(0.25);
+	});
+
+	it("handles instantaneous and invalid cues without invalid CSS values", () => {
+		for (const durationMs of [0, -1]) {
+			expect(wordProgress({ ...word, durationMs }, 999)).toBe(0);
+			expect(wordProgress({ ...word, durationMs }, 1000)).toBe(1);
+		}
+		expect(wordProgress({ ...word, durationMs: Infinity }, 2000)).toBe(0);
+		expect(wordProgress({ ...word, timeMs: NaN }, 2000)).toBe(0);
+		expect(wordProgress(word, NaN)).toBe(0);
+	});
+});

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/progress.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/progress.ts
@@ -1,0 +1,9 @@
+import type { LyricWord } from "./types";
+
+/** Absolute playback time keeps fills correct through pauses, seeks and overlapping cues. */
+export function wordProgress(word: LyricWord, timeMs: number): number {
+	if (!Number.isFinite(timeMs) || !Number.isFinite(word.timeMs) || timeMs < word.timeMs) return 0;
+	if (!Number.isFinite(word.durationMs)) return 0;
+	if (word.durationMs <= 0) return 1;
+	return Math.min(1, (timeMs - word.timeMs) / word.durationMs);
+}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.test.ts
@@ -45,6 +45,33 @@ describe("searchBetterLyrics", () => {
 		expect(lastRequestHeaders().get("x-api-key")).toBe("secret");
 	});
 
+	it("retries a keyless 401 without the album, since album is part of the cache key", async () => {
+		const urls: string[] = [];
+		fetchMock.mockImplementation(async (input) => {
+			const url = input instanceof Request ? input.url : String(input);
+			urls.push(url);
+			return new URL(url).searchParams.has("al")
+				? jsonResponse(401, { error: "API key required" })
+				: jsonResponse(200, { ttml: TTML });
+		});
+
+		const reasons: LyricsMissReason[] = [];
+		const result = await searchBetterLyrics({ ...info, album: "÷ (Deluxe)" }, { onMiss: (r) => reasons.push(r) });
+		expect(result?.provider).toBe("better-lyrics");
+		expect(reasons).toEqual([]);
+		expect(urls.map((u) => new URL(u).searchParams.get("al"))).toEqual(["÷ (Deluxe)", null]);
+
+		// With a key, 401 means the key was rejected — no point retrying.
+		urls.length = 0;
+		fetchMock.mockImplementation(async (input) => {
+			urls.push(input instanceof Request ? input.url : String(input));
+			return jsonResponse(401, { error: "invalid key" });
+		});
+		expect(await searchBetterLyrics({ ...info, album: "÷ (Deluxe)" }, { apiKey: "k", onMiss: (r) => reasons.push(r) })).toBeNull();
+		expect(urls).toHaveLength(1);
+		expect(reasons).toEqual(["invalid-key"]);
+	});
+
 	it("reports 401 as uncached without a key, invalid-key with one", async () => {
 		fetchMock.mockImplementation(async () => jsonResponse(401, { error: "API key required" }));
 

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LyricsMissReason, TrackSearchInfo } from "../types";
+import { searchBetterLyrics } from "./better-lyrics";
+
+const info: TrackSearchInfo = {
+	videoId: "dQw4w9WgXcQ",
+	title: "Never Gonna Give You Up",
+	artist: "Rick Astley",
+	durationSec: 213,
+};
+
+const TTML = `<tt xmlns="http://www.w3.org/ns/ttml"><body><div><p begin="00:00:01.000" end="00:00:02.000">hi</p></div></body></tt>`;
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("searchBetterLyrics", () => {
+	const fetchMock = vi.fn<typeof fetch>();
+
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function lastRequestHeaders(): Headers {
+		const [input, init] = fetchMock.mock.calls.at(-1) ?? [];
+		if (input instanceof Request) return input.headers;
+		return new Headers(init?.headers);
+	}
+
+	it("sends X-API-Key only when a key is set", async () => {
+		fetchMock.mockImplementation(async () => jsonResponse(200, { ttml: TTML }));
+
+		await searchBetterLyrics(info);
+		expect(lastRequestHeaders().get("x-api-key")).toBeNull();
+
+		await searchBetterLyrics(info, { apiKey: "  secret  " });
+		expect(lastRequestHeaders().get("x-api-key")).toBe("secret");
+	});
+
+	it("reports 401 as uncached without a key, invalid-key with one", async () => {
+		fetchMock.mockImplementation(async () => jsonResponse(401, { error: "API key required" }));
+
+		const reasons: LyricsMissReason[] = [];
+		expect(await searchBetterLyrics(info, { onMiss: (r) => reasons.push(r) })).toBeNull();
+		expect(await searchBetterLyrics(info, { apiKey: "bad", onMiss: (r) => reasons.push(r) })).toBeNull();
+		expect(reasons).toEqual(["uncached", "invalid-key"]);
+	});
+
+	it("maps 404 / 429 to soft misses and throws on other errors", async () => {
+		const reasons: LyricsMissReason[] = [];
+		const onMiss = (r: LyricsMissReason) => reasons.push(r);
+
+		fetchMock.mockResolvedValueOnce(jsonResponse(404, { error: "not found" }));
+		expect(await searchBetterLyrics(info, { onMiss })).toBeNull();
+		fetchMock.mockResolvedValueOnce(jsonResponse(429, { error: "slow down" }));
+		expect(await searchBetterLyrics(info, { onMiss })).toBeNull();
+		expect(reasons).toEqual(["not-found", "rate-limited"]);
+
+		fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: "boom" }));
+		await expect(searchBetterLyrics(info, { onMiss })).rejects.toThrow("Better Lyrics HTTP 500");
+		expect(reasons).toHaveLength(2);
+	});
+});

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.ts
@@ -39,16 +39,24 @@ export async function searchBetterLyrics(
 		s: info.title,
 		a: info.artist,
 	};
-	if (info.album) query.al = info.album;
 	if (info.durationSec > 0) query.d = Math.round(info.durationSec);
 	if (info.videoId) query.videoId = info.videoId;
 
 	const apiKey = options.apiKey?.trim();
-	const { data, error } = await blFetch<BetterLyricsResponse>("/getLyrics", {
-		query,
-		...(apiKey ? { headers: { "X-API-Key": apiKey } } : {}),
-		...(options.signal ? { signal: options.signal } : {}),
-	});
+	const request = (q: Record<string, string | number>) =>
+		blFetch<BetterLyricsResponse>("/getLyrics", {
+			query: q,
+			...(apiKey ? { headers: { "X-API-Key": apiKey } } : {}),
+			...(options.signal ? { signal: options.signal } : {}),
+		});
+
+	// The album is part of the cache key. YTM's album string (e.g. "÷ (Deluxe)") often differs
+	// from what the extension cached the song under, so a keyless 401 with the album set is
+	// retried without it before we call the song uncached.
+	let { data, error } = await (info.album ? request({ ...query, al: info.album }) : request(query));
+	if (error?.status === 401 && !apiKey && info.album) {
+		({ data, error } = await request(query));
+	}
 
 	if (error) {
 		// 401 = cache miss without key (or rejected key); 404 = no lyrics; 429 = rate limited.

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/better-lyrics.ts
@@ -1,6 +1,6 @@
 import { createFetch } from "@better-fetch/fetch";
 import { parseTtml, ttmlHasWordSync } from "../ttml";
-import type { LyricResult, TrackSearchInfo } from "../types";
+import type { LyricResult, LyricsMissReason, TrackSearchInfo } from "../types";
 
 /** Public Better Lyrics API — https://lyrics-api-docs.boidu.dev */
 const blFetch = createFetch({
@@ -13,6 +13,10 @@ const blFetch = createFetch({
 
 export interface BetterLyricsSearchOptions {
 	signal?: AbortSignal;
+	/** Optional `X-API-Key`; unlocks cache misses and rate-limit bypass. */
+	apiKey?: string;
+	/** Called on a soft miss (null result) with why, so the UI can hint at a fix. */
+	onMiss?: (reason: LyricsMissReason) => void;
 }
 
 interface BetterLyricsResponse {
@@ -24,7 +28,8 @@ interface BetterLyricsResponse {
 
 /**
  * Fetch syllable/word-synced TTML from Better Lyrics public API.
- * Cache hits are free; uncached misses may 401 without an API key — caller should fall back.
+ * Cache hits are free; uncached misses 401 without an API key — caller should fall back.
+ * With a key, 401 means the key was rejected (`X-Auth-Mode: invalid`).
  */
 export async function searchBetterLyrics(
 	info: TrackSearchInfo,
@@ -38,22 +43,42 @@ export async function searchBetterLyrics(
 	if (info.durationSec > 0) query.d = Math.round(info.durationSec);
 	if (info.videoId) query.videoId = info.videoId;
 
+	const apiKey = options.apiKey?.trim();
 	const { data, error } = await blFetch<BetterLyricsResponse>("/getLyrics", {
 		query,
+		...(apiKey ? { headers: { "X-API-Key": apiKey } } : {}),
 		...(options.signal ? { signal: options.signal } : {}),
 	});
 
 	if (error) {
-		// 401 = cache miss without key; 404 = no lyrics — soft miss for fallback.
-		if (error.status === 401 || error.status === 404 || error.status === 429) return null;
+		// 401 = cache miss without key (or rejected key); 404 = no lyrics; 429 = rate limited.
+		// All are soft misses so the next provider gets a turn.
+		if (error.status === 401) {
+			options.onMiss?.(apiKey ? "invalid-key" : "uncached");
+			return null;
+		}
+		if (error.status === 404) {
+			options.onMiss?.("not-found");
+			return null;
+		}
+		if (error.status === 429) {
+			options.onMiss?.("rate-limited");
+			return null;
+		}
 		throw new Error(`Better Lyrics HTTP ${error.status}`);
 	}
 
 	const ttml = data?.ttml?.trim();
-	if (!ttml) return null;
+	if (!ttml) {
+		options.onMiss?.("not-found");
+		return null;
+	}
 
 	const lines = parseTtml(ttml);
-	if (!lines.length) return null;
+	if (!lines.length) {
+		options.onMiss?.("not-found");
+		return null;
+	}
 	const hasWordSync = ttmlHasWordSync(ttml) || lines.some((l) => !!l.words?.length);
 
 	return {

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/catalog.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/catalog.ts
@@ -1,4 +1,4 @@
-export const LYRICS_PROVIDER_IDS = ["better-lyrics", "unison", "lrclib"] as const;
+export const LYRICS_PROVIDER_IDS = ["better-lyrics", "unison", "lrclib", "youtube-captions"] as const;
 
 export type LyricsProviderId = (typeof LYRICS_PROVIDER_IDS)[number];
 
@@ -31,8 +31,14 @@ export const LYRICS_PROVIDER_META: Record<LyricsProviderId, LyricsProviderMeta> 
 	lrclib: {
 		id: "lrclib",
 		label: "LRCLib",
-		syncLevels: "Line & plain",
+		syncLevels: "Word, line & plain",
 		href: "https://lrclib.net",
+	},
+	"youtube-captions": {
+		id: "youtube-captions",
+		label: "YouTube captions",
+		syncLevels: "Line (music videos with captions)",
+		href: "https://support.google.com/youtube/answer/2734796",
 	},
 };
 
@@ -40,7 +46,11 @@ export const DEFAULT_LYRICS_PROVIDERS: LyricsProviderEntry[] = [
 	{ id: "better-lyrics", enabled: true },
 	{ id: "unison", enabled: true },
 	{ id: "lrclib", enabled: true },
+	{ id: "youtube-captions", enabled: true },
 ];
+
+/** Providers that can only describe the *current* player video — skipped when prefetching "up next". */
+export const CURRENT_VIDEO_ONLY_PROVIDERS: ReadonlySet<LyricsProviderId> = new Set<LyricsProviderId>(["youtube-captions"]);
 
 function isProviderId(value: unknown): value is LyricsProviderId {
 	return typeof value === "string" && (LYRICS_PROVIDER_IDS as readonly string[]).includes(value);

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/lrclib.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/lrclib.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { pickBest, rankLrcLibHits } from "./lrclib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { lrcLibTitleVariants, pickBest, rankLrcLibHits, searchLrcLib } from "./lrclib";
 
 const baseHit = {
 	id: 1,
@@ -32,5 +32,124 @@ describe("pickBest / rankLrcLibHits", () => {
 		const picked = pickBest([far], { ...info, durationSec: 200 }, true);
 		expect(picked).toMatchObject({ inexact: true, hit: { duration: 250 } });
 		expect(pickBest([far], info, false)).toBeNull();
+	});
+});
+
+describe("searchLrcLib sync level", () => {
+	const fetchMock = vi.fn<typeof fetch>();
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	const respond = (syncedLyrics: string) =>
+		fetchMock.mockImplementation(
+			async () =>
+				new Response(JSON.stringify([{ ...baseHit, syncedLyrics }]), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+
+	it("stays line-level for plain LRC", async () => {
+		respond("[00:01.00] hello\n[00:02.00] world");
+		const result = await searchLrcLib(info, { showEvenIfInexact: true });
+		expect(result).toMatchObject({ provider: "lrclib", syncLevel: "line", hasWordSync: false });
+	});
+
+	it("exposes word sync when LRCLib returns enhanced LRC", async () => {
+		respond("[00:01.00] <00:01.00>hello <00:01.50>big <00:01.80>world\n[00:02.00] plain");
+		const result = await searchLrcLib(info, { showEvenIfInexact: true });
+		expect(result).toMatchObject({ syncLevel: "word", hasWordSync: true });
+		const worded = result?.lines?.find((l) => l.words?.length);
+		expect(worded?.words?.map((w) => w.text.trim())).toEqual(["hello", "big", "world"]);
+	});
+});
+
+describe("lrcLibTitleVariants", () => {
+	it("splits `原題 - romaji (english)` titles into queryable parts", () => {
+		expect(lrcLibTitleVariants("真っ白 - masshiro (pure white)")).toEqual([
+			"真っ白 - masshiro (pure white)",
+			"真っ白",
+			"masshiro (pure white)",
+			"masshiro",
+			"真っ白 - masshiro",
+		]);
+	});
+
+	it("strips feat. and bracket suffixes, keeps plain titles as-is", () => {
+		expect(lrcLibTitleVariants("Shape of You")).toEqual(["Shape of You"]);
+		expect(lrcLibTitleVariants("Song [Remastered 2011] feat. Someone")).toEqual([
+			"Song [Remastered 2011] feat. Someone",
+			"Song [Remastered 2011]",
+		]);
+	});
+});
+
+describe("rankLrcLibHits sync preference", () => {
+	it("prefers a synced hit over a closer plain-only hit within tolerance", () => {
+		const plainClose = { ...baseHit, id: 1, duration: 200, syncedLyrics: null };
+		const syncedFar = { ...baseHit, id: 2, duration: 205, syncedLyrics: "[00:01.00] a" };
+		expect(rankLrcLibHits([plainClose, syncedFar], info)[0].hit.id).toBe(2);
+	});
+
+	it("still keeps out-of-tolerance synced hits behind in-tolerance plain hits", () => {
+		const plainClose = { ...baseHit, id: 1, duration: 200, syncedLyrics: null };
+		const syncedWayOff = { ...baseHit, id: 2, duration: 260, syncedLyrics: "[00:01.00] a" };
+		expect(rankLrcLibHits([plainClose, syncedWayOff], info)[0].hit.id).toBe(1);
+	});
+});
+
+describe("searchLrcLib title variants", () => {
+	const fetchMock = vi.fn<typeof fetch>();
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	const kaze = { videoId: "k", title: "真っ白 - masshiro (pure white)", artist: "Fujii Kaze", durationSec: 297 };
+	const hit = (id: number, trackName: string, duration: number, synced: boolean) => ({
+		id,
+		trackName,
+		artistName: "Fujii Kaze",
+		albumName: "Prema",
+		duration,
+		instrumental: false,
+		plainLyrics: "plain",
+		syncedLyrics: synced ? "[00:01.00] line" : null,
+	});
+
+	it("keeps querying variants until a synced in-tolerance hit appears, then picks it", async () => {
+		// Mirrors real LRCLib responses: full title → plain-only (+ a short acapella), "masshiro" → synced.
+		fetchMock.mockImplementation(async (input) => {
+			const url = new URL(String(input instanceof Request ? input.url : input));
+			const track = url.searchParams.get("track_name");
+			const body =
+				track === kaze.title
+					? [hit(1, kaze.title, 295, false), hit(2, `${kaze.title} (Acapella)`, 272, true)]
+					: track === "masshiro"
+						? [hit(3, "masshiro", 294, false), hit(4, "masshiro (pure white)", 294, true)]
+						: [];
+			return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+		});
+
+		const result = await searchLrcLib(kaze, { showEvenIfInexact: true });
+		expect(result).toMatchObject({ title: "masshiro (pure white)", syncLevel: "line", inexact: false });
+		const queried = fetchMock.mock.calls.map((c) => new URL(String(c[0] instanceof Request ? c[0].url : c[0])).searchParams.get("track_name"));
+		expect(queried).toEqual([kaze.title, "真っ白", "masshiro (pure white)", "masshiro"]);
+	});
+
+	it("stops after the first query when it already has a synced hit", async () => {
+		fetchMock.mockImplementation(
+			async () => new Response(JSON.stringify([hit(9, kaze.title, 296, true)]), { status: 200, headers: { "content-type": "application/json" } }),
+		);
+		await searchLrcLib(kaze, { showEvenIfInexact: true });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/lrclib.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/lrclib.ts
@@ -46,7 +46,14 @@ async function searchApi(params: URLSearchParams, signal?: AbortSignal): Promise
 	return data;
 }
 
-/** Rank by duration match, then artist score. Line-synced only (no word sync). */
+function hasSynced(hit: LrcLibHit): boolean {
+	return !!hit.syncedLyrics?.trim();
+}
+
+/**
+ * Rank: duration within tolerance first, then synced before plain-only, then closest duration, then artist score.
+ * Timed lines are the whole point of the provider, so a synced hit a few seconds off beats a plain-only exact match.
+ */
 export function rankLrcLibHits(hits: LrcLibHit[], info: TrackSearchInfo): RankedLrcLibHit[] {
 	return hits
 		.map((hit) => {
@@ -59,9 +66,34 @@ export function rankLrcLibHits(hits: LrcLibHit[], info: TrackSearchInfo): Ranked
 			const aExact = a.durationDelta <= DURATION_TOLERANCE_SEC ? 0 : 1;
 			const bExact = b.durationDelta <= DURATION_TOLERANCE_SEC ? 0 : 1;
 			if (aExact !== bExact) return aExact - bExact;
+			const aSynced = hasSynced(a.hit) ? 0 : 1;
+			const bSynced = hasSynced(b.hit) ? 0 : 1;
+			if (aSynced !== bSynced) return aSynced - bSynced;
 			if (a.durationDelta !== b.durationDelta) return a.durationDelta - b.durationDelta;
 			return b.artistRatio - a.artistRatio;
 		});
+}
+
+/**
+ * Alternate spellings of a YTM title worth querying when the full title finds no synced hit.
+ * YTM (esp. JP/KR releases) often titles tracks `原題 - romaji (english)`; LRCLib entries use any one of the parts.
+ */
+export function lrcLibTitleVariants(title: string): string[] {
+	const out: string[] = [];
+	const push = (s: string) => {
+		const t = s.replace(/\s+/g, " ").trim();
+		if (t && !out.includes(t)) out.push(t);
+	};
+	const stripSuffix = (s: string) => s.replace(/\s*[([][^)\]]*[)\]]\s*$/g, "").replace(/\s*(?:feat|ft)\.?\s.*$/i, "");
+
+	push(title);
+	const parts = title.split(/\s+[-–—/|]\s+/);
+	for (const part of parts) {
+		push(part);
+		push(stripSuffix(part));
+	}
+	push(stripSuffix(title));
+	return out.slice(0, 5);
 }
 
 export function pickBest(
@@ -88,33 +120,50 @@ function toResult(hit: LrcLibHit, inexact: boolean): LyricResult | null {
 	const synced = hit.syncedLyrics?.trim();
 	const plain = hit.plainLyrics?.trim();
 	if (!synced && !plain) return null;
+	const lines = synced ? parseLrc(synced) : undefined;
+	// LRCLib is usually plain `[mm:ss.xx]` LRC, but enhanced `<mm:ss.xx>` word tags do show up — honor them.
+	const hasWordSync = !!lines?.some((l) => !!l.words?.length);
 	return {
 		title: hit.trackName,
 		artists: artistsFromHit(hit.artistName),
-		...(synced ? { lines: parseLrc(synced) } : {}),
+		...(lines ? { lines } : {}),
 		...(plain ? { plain } : {}),
 		inexact,
 		provider: "lrclib",
-		hasWordSync: false,
-		syncLevel: synced ? "line" : "plain",
+		hasWordSync,
+		syncLevel: hasWordSync ? "word" : synced ? "line" : "plain",
 	};
 }
 
-/** Fetch line-synced / plain lyrics from LRCLib. */
+/** True when `hits` already contain a synced, artist-matched entry within duration tolerance — no need to keep querying. */
+function hasGoodSyncedHit(hits: LrcLibHit[], info: TrackSearchInfo): boolean {
+	const best = rankLrcLibHits(hits, info)[0];
+	return !!best && best.durationDelta <= DURATION_TOLERANCE_SEC && hasSynced(best.hit);
+}
+
+/**
+ * Fetch line-synced / plain lyrics from LRCLib.
+ * Queries the full title first, then title variants until a synced in-tolerance hit shows up; hits are pooled
+ * (deduped by id) so a plain-only exact match never hides a synced entry filed under another spelling.
+ */
 export async function searchLrcLib(info: TrackSearchInfo, options: LrcLibSearchOptions): Promise<LyricResult | null> {
-	const params = new URLSearchParams({
-		artist_name: info.artist,
-		track_name: info.title,
-	});
-	if (info.album) params.set("album_name", info.album);
+	const pooled = new Map<number, LrcLibHit>();
+	const collect = (hits: LrcLibHit[]) => {
+		for (const hit of hits) if (!pooled.has(hit.id)) pooled.set(hit.id, hit);
+	};
 
-	let hits = await searchApi(params, options.signal);
-
-	if (!hits.length && options.showEvenIfInexact) {
-		hits = await searchApi(new URLSearchParams({ q: info.title }), options.signal);
+	for (const title of lrcLibTitleVariants(info.title)) {
+		const params = new URLSearchParams({ artist_name: info.artist, track_name: title });
+		if (info.album && title === info.title) params.set("album_name", info.album);
+		collect(await searchApi(params, options.signal));
+		if (hasGoodSyncedHit([...pooled.values()], info)) break;
 	}
 
-	const picked = pickBest(hits, info, options.showEvenIfInexact);
+	if (!pooled.size && options.showEvenIfInexact) {
+		collect(await searchApi(new URLSearchParams({ q: info.title }), options.signal));
+	}
+
+	const picked = pickBest([...pooled.values()], info, options.showEvenIfInexact);
 	if (!picked) return null;
 	return toResult(picked.hit, picked.inexact);
 }

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.test.ts
@@ -165,3 +165,40 @@ describe("searchLyricsDetailed prefetch", () => {
 	});
 });
 
+describe("searchLyricsDetailed preferWordSync", () => {
+	beforeEach(() => {
+		vi.mocked(searchBetterLyrics).mockReset();
+		vi.mocked(searchUnison).mockReset();
+		vi.mocked(searchLrcLib).mockReset();
+		vi.mocked(searchYouTubeCaptions).mockReset();
+	});
+
+	const wordHit = (): LyricResult => ({ ...hit("unison"), hasWordSync: true, syncLevel: "syllable" });
+	const order = [
+		{ id: "lrclib", enabled: true },
+		{ id: "unison", enabled: true },
+		{ id: "better-lyrics", enabled: false },
+		{ id: "youtube-captions", enabled: false },
+	];
+
+	it("keeps searching past a line-synced hit for word sync, then falls back to it", async () => {
+		vi.mocked(searchLrcLib).mockResolvedValue(hit("lrclib"));
+		vi.mocked(searchUnison).mockResolvedValue(wordHit());
+
+		const preferred = await searchLyricsDetailed(info, { showEvenIfInexact: true, providers: order, preferWordSync: true });
+		expect(preferred.result?.provider).toBe("unison");
+
+		vi.mocked(searchUnison).mockResolvedValue(null);
+		const fallback = await searchLyricsDetailed(info, { showEvenIfInexact: true, providers: order, preferWordSync: true });
+		expect(fallback.result?.provider).toBe("lrclib");
+	});
+
+	it("stops at the first timed hit when disabled", async () => {
+		vi.mocked(searchLrcLib).mockResolvedValue(hit("lrclib"));
+		vi.mocked(searchUnison).mockResolvedValue(wordHit());
+
+		const outcome = await searchLyricsDetailed(info, { showEvenIfInexact: true, providers: order, preferWordSync: false });
+		expect(outcome.result?.provider).toBe("lrclib");
+		expect(searchUnison).not.toHaveBeenCalled();
+	});
+});

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.test.ts
@@ -5,11 +5,13 @@ import { enabledLyricsProviderIds, LYRICS_PROVIDER_META, moveLyricsProvider, nor
 vi.mock("./better-lyrics", () => ({ searchBetterLyrics: vi.fn() }));
 vi.mock("./unison", () => ({ searchUnison: vi.fn() }));
 vi.mock("./lrclib", () => ({ searchLrcLib: vi.fn() }));
+vi.mock("./youtube-captions", () => ({ searchYouTubeCaptions: vi.fn() }));
 
 import { searchBetterLyrics } from "./better-lyrics";
 import { searchLrcLib } from "./lrclib";
+import { searchLyrics, searchLyricsDetailed } from "./search";
 import { searchUnison } from "./unison";
-import { searchLyrics } from "./search";
+import { searchYouTubeCaptions } from "./youtube-captions";
 
 const info: TrackSearchInfo = {
 	videoId: "dQw4w9WgXcQ",
@@ -36,26 +38,27 @@ describe("catalog", () => {
 			{ id: "lrclib", enabled: true },
 			{ id: "better-lyrics", enabled: true },
 			{ id: "unison", enabled: true },
+			{ id: "youtube-captions", enabled: true },
 		]);
 		expect(
 			enabledLyricsProviderIds([
 				{ id: "better-lyrics", enabled: false },
 				{ id: "unison", enabled: true },
 			]),
-		).toEqual(["unison", "lrclib"]);
+		).toEqual(["unison", "lrclib", "youtube-captions"]);
 	});
 
 	it("supports Providers card reorder + toggle", () => {
 		const base = normalizeLyricsProviders(undefined);
 		const moved = moveLyricsProvider(base, 0, 2);
-		expect(moved?.map((e) => e.id)).toEqual(["unison", "lrclib", "better-lyrics"]);
+		expect(moved?.map((e) => e.id)).toEqual(["unison", "lrclib", "better-lyrics", "youtube-captions"]);
 		expect(moveLyricsProvider(base, 0, 0)).toBeNull();
 
 		const toggled = setLyricsProviderEnabled(base, "lrclib", false);
 		expect(toggled.find((e) => e.id === "lrclib")?.enabled).toBe(false);
-		expect(enabledLyricsProviderIds(toggled)).toEqual(["better-lyrics", "unison"]);
+		expect(enabledLyricsProviderIds(toggled)).toEqual(["better-lyrics", "unison", "youtube-captions"]);
 
-		for (const id of ["better-lyrics", "unison", "lrclib"] as const) {
+		for (const id of ["better-lyrics", "unison", "lrclib", "youtube-captions"] as const) {
 			expect(LYRICS_PROVIDER_META[id].href).toMatch(/^https:\/\//);
 			expect(LYRICS_PROVIDER_META[id].label.length).toBeGreaterThan(0);
 		}
@@ -104,3 +107,61 @@ describe("searchLyrics", () => {
 		expect(searchLrcLib).toHaveBeenCalledOnce();
 	});
 });
+
+describe("searchLyricsDetailed", () => {
+	beforeEach(() => {
+		vi.mocked(searchBetterLyrics).mockReset();
+		vi.mocked(searchUnison).mockReset();
+		vi.mocked(searchLrcLib).mockReset();
+	});
+
+	it("forwards the API key and surfaces the Better Lyrics miss reason when nothing is found", async () => {
+		vi.mocked(searchBetterLyrics).mockImplementation(async (_info, options) => {
+			options?.onMiss?.("uncached");
+			return null;
+		});
+		vi.mocked(searchUnison).mockResolvedValue(null);
+		vi.mocked(searchLrcLib).mockResolvedValue(null);
+
+		const outcome = await searchLyricsDetailed(info, { showEvenIfInexact: true, betterLyricsApiKey: "k" });
+		expect(outcome).toEqual({ result: null, betterLyricsMiss: "uncached" });
+		expect(vi.mocked(searchBetterLyrics).mock.calls[0]?.[1]).toMatchObject({ apiKey: "k" });
+	});
+
+	it("keeps the miss reason even when a later provider wins", async () => {
+		vi.mocked(searchBetterLyrics).mockImplementation(async (_info, options) => {
+			options?.onMiss?.("uncached");
+			return null;
+		});
+		vi.mocked(searchUnison).mockResolvedValue(hit("unison"));
+
+		const outcome = await searchLyricsDetailed(info, { showEvenIfInexact: true });
+		expect(outcome.result?.provider).toBe("unison");
+		expect(outcome.betterLyricsMiss).toBe("uncached");
+	});
+});
+
+describe("searchLyricsDetailed prefetch", () => {
+	beforeEach(() => {
+		vi.mocked(searchBetterLyrics).mockReset();
+		vi.mocked(searchUnison).mockReset();
+		vi.mocked(searchLrcLib).mockReset();
+		vi.mocked(searchYouTubeCaptions).mockReset();
+	});
+
+	it("skips current-video-only providers and flags the outcome as partial", async () => {
+		vi.mocked(searchBetterLyrics).mockResolvedValue(null);
+		vi.mocked(searchUnison).mockResolvedValue(null);
+		vi.mocked(searchLrcLib).mockResolvedValue(null);
+		vi.mocked(searchYouTubeCaptions).mockResolvedValue(hit("youtube-captions"));
+
+		const outcome = await searchLyricsDetailed(info, { showEvenIfInexact: true, prefetch: true });
+		expect(outcome).toMatchObject({ result: null, partial: true });
+		expect(searchYouTubeCaptions).not.toHaveBeenCalled();
+
+		const full = await searchLyricsDetailed(info, { showEvenIfInexact: true });
+		expect(full.result?.provider).toBe("youtube-captions");
+		expect(full.partial).toBeUndefined();
+	});
+});
+

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.ts
@@ -1,23 +1,43 @@
-import { enabledLyricsProviderIds, type LyricsProviderId } from "./catalog";
+import type { LyricResult, LyricsMissReason, TrackSearchInfo } from "../types";
 import { searchBetterLyrics } from "./better-lyrics";
+import { CURRENT_VIDEO_ONLY_PROVIDERS, enabledLyricsProviderIds, type LyricsProviderId } from "./catalog";
 import { searchLrcLib } from "./lrclib";
 import { searchUnison } from "./unison";
-import type { LyricResult, TrackSearchInfo } from "../types";
+import { searchYouTubeCaptions } from "./youtube-captions";
 
 export interface LyricsSearchOptions {
 	showEvenIfInexact: boolean;
 	providers?: unknown;
+	/** Better Lyrics `X-API-Key` (optional; empty = cache-only access). */
+	betterLyricsApiKey?: string;
+	/** Background "up next" lookup: providers that only see the current player video are skipped. */
+	prefetch?: boolean;
 	signal?: AbortSignal;
+}
+
+export interface LyricsSearchOutcome {
+	result: LyricResult | null;
+	/** Set when Better Lyrics was tried and returned nothing; explains the empty state. */
+	betterLyricsMiss?: LyricsMissReason;
+	/** True when at least one enabled provider was skipped (prefetch) — the outcome is not final. */
+	partial?: boolean;
 }
 
 async function runProvider(
 	id: LyricsProviderId,
 	info: TrackSearchInfo,
 	options: LyricsSearchOptions,
+	outcome: LyricsSearchOutcome,
 ): Promise<LyricResult | null> {
 	switch (id) {
 		case "better-lyrics":
-			return searchBetterLyrics(info, { signal: options.signal });
+			return searchBetterLyrics(info, {
+				signal: options.signal,
+				apiKey: options.betterLyricsApiKey,
+				onMiss: (reason) => {
+					outcome.betterLyricsMiss = reason;
+				},
+			});
 		case "unison":
 			return searchUnison(info, { signal: options.signal });
 		case "lrclib":
@@ -25,6 +45,8 @@ async function runProvider(
 				showEvenIfInexact: options.showEvenIfInexact,
 				signal: options.signal,
 			});
+		case "youtube-captions":
+			return searchYouTubeCaptions(info, { signal: options.signal });
 		default:
 			return null;
 	}
@@ -42,20 +64,37 @@ function isPlainOnly(result: LyricResult | null | undefined): boolean {
  * Try enabled providers in user order.
  * Timed (line/syllable) wins immediately; plain is kept as fallback so later providers can still supply sync.
  */
-export async function searchLyrics(
+export async function searchLyricsDetailed(
 	info: TrackSearchInfo,
 	options: LyricsSearchOptions,
-): Promise<LyricResult | null> {
+): Promise<LyricsSearchOutcome> {
 	const order = enabledLyricsProviderIds(options.providers);
+	const outcome: LyricsSearchOutcome = { result: null };
 	let plainFallback: LyricResult | null = null;
 	for (const id of order) {
+		if (options.prefetch && CURRENT_VIDEO_ONLY_PROVIDERS.has(id)) {
+			outcome.partial = true;
+			continue;
+		}
 		try {
-			const result = await runProvider(id, info, options);
-			if (isTimed(result)) return result;
+			const result = await runProvider(id, info, options, outcome);
+			if (isTimed(result)) {
+				outcome.result = result;
+				return outcome;
+			}
 			if (isPlainOnly(result) && !plainFallback) plainFallback = result;
 		} catch {
 			/* try next provider */
 		}
 	}
-	return plainFallback;
+	outcome.result = plainFallback;
+	return outcome;
+}
+
+/** Result-only convenience over {@link searchLyricsDetailed}. */
+export async function searchLyrics(
+	info: TrackSearchInfo,
+	options: LyricsSearchOptions,
+): Promise<LyricResult | null> {
+	return (await searchLyricsDetailed(info, options)).result;
 }

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/search.ts
@@ -12,6 +12,8 @@ export interface LyricsSearchOptions {
 	betterLyricsApiKey?: string;
 	/** Background "up next" lookup: providers that only see the current player video are skipped. */
 	prefetch?: boolean;
+	/** Keep trying later providers for word/syllable cues before settling for a line-synced hit. */
+	preferWordSync?: boolean;
 	signal?: AbortSignal;
 }
 
@@ -60,9 +62,15 @@ function isPlainOnly(result: LyricResult | null | undefined): boolean {
 	return !!result?.plain?.trim() && !result?.lines?.length;
 }
 
+function isWordSynced(result: LyricResult | null | undefined): boolean {
+	return isTimed(result) && (!!result?.hasWordSync || !!result?.lines?.some((l) => !!l.words?.length));
+}
+
 /**
  * Try enabled providers in user order.
  * Timed (line/syllable) wins immediately; plain is kept as fallback so later providers can still supply sync.
+ * With `preferWordSync`, only word/syllable-synced results win immediately — a line-synced hit is kept as a
+ * fallback while later providers get a chance to supply word cues.
  */
 export async function searchLyricsDetailed(
 	info: TrackSearchInfo,
@@ -70,6 +78,7 @@ export async function searchLyricsDetailed(
 ): Promise<LyricsSearchOutcome> {
 	const order = enabledLyricsProviderIds(options.providers);
 	const outcome: LyricsSearchOutcome = { result: null };
+	let timedFallback: LyricResult | null = null;
 	let plainFallback: LyricResult | null = null;
 	for (const id of order) {
 		if (options.prefetch && CURRENT_VIDEO_ONLY_PROVIDERS.has(id)) {
@@ -79,15 +88,19 @@ export async function searchLyricsDetailed(
 		try {
 			const result = await runProvider(id, info, options, outcome);
 			if (isTimed(result)) {
-				outcome.result = result;
-				return outcome;
+				if (!options.preferWordSync || isWordSynced(result)) {
+					outcome.result = result;
+					return outcome;
+				}
+				if (!timedFallback) timedFallback = result;
+				continue;
 			}
 			if (isPlainOnly(result) && !plainFallback) plainFallback = result;
 		} catch {
 			/* try next provider */
 		}
 	}
-	outcome.result = plainFallback;
+	outcome.result = timedFallback ?? plainFallback;
 	return outcome;
 }
 

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/youtube-captions.test.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/youtube-captions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TrackSearchInfo, YouTubeCaptionTrack } from "../types";
+
+vi.mock("../../lyrics.page", () => ({ lyricsPage: { request: vi.fn() } }));
+
+import { normalizeCaptionCase, parseJson3Captions, pickCaptionTrack, searchYouTubeCaptions } from "./youtube-captions";
+
+const info: TrackSearchInfo = {
+	videoId: "vid1",
+	title: "Song",
+	artist: "Artist & Friend",
+	durationSec: 200,
+};
+
+function track(partial: Partial<YouTubeCaptionTrack>): YouTubeCaptionTrack {
+	return { languageCode: "en", url: "https://www.youtube.com/api/timedtext?v=vid1&lang=en", isAuto: false, name: "English", ...partial };
+}
+
+describe("pickCaptionTrack", () => {
+	it("ignores auto-generated tracks entirely", () => {
+		expect(pickCaptionTrack([track({ isAuto: true })])).toBeNull();
+	});
+
+	it("prefers the manual track in the video's spoken (ASR) language", () => {
+		const picked = pickCaptionTrack([
+			track({ languageCode: "en", name: "English" }),
+			track({ languageCode: "ja", name: "Japanese" }),
+			track({ languageCode: "ja-JP", isAuto: true, name: "Japanese (auto-generated)" }),
+		]);
+		expect(picked?.name).toBe("Japanese");
+	});
+
+	it("falls back to the first manual track", () => {
+		expect(pickCaptionTrack([track({ isAuto: true, languageCode: "ko" }), track({ languageCode: "en" })])?.languageCode).toBe("en");
+	});
+});
+
+describe("parseJson3Captions", () => {
+	it("drops sound cues, strips note glyphs, keeps explicit durations", () => {
+		const lines = parseJson3Captions({
+			events: [
+				{ tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "[Music]" }] },
+				{ tStartMs: 1000, dDurationMs: 1500, segs: [{ utf8: "♪ Hello there ♪" }] },
+				{ tStartMs: 1500, wWinId: 1 },
+				{ tStartMs: 4000, dDurationMs: 2000, segs: [{ utf8: "second\nline" }] },
+			],
+		});
+		expect(lines).toEqual([
+			{ timeMs: 0, text: "", durationMs: 1000 },
+			{ timeMs: 1000, text: "Hello there", durationMs: 1500 },
+			{ timeMs: 4000, text: "second line", durationMs: 2000 },
+		]);
+	});
+
+	it("turns per-segment offsets into word cues", () => {
+		const [line] = parseJson3Captions({
+			events: [{ tStartMs: 0, dDurationMs: 900, segs: [{ utf8: "one" }, { utf8: " two", tOffsetMs: 300 }, { utf8: " three", tOffsetMs: 600 }] }],
+		});
+		expect(line.text).toBe("one two three");
+		expect(line.words).toEqual([
+			{ timeMs: 0, text: "one", durationMs: 300 },
+			{ timeMs: 300, text: " two", durationMs: 300 },
+			{ timeMs: 600, text: " three", durationMs: 300 },
+		]);
+	});
+
+	it("skips rolling-append events and tolerates junk", () => {
+		expect(parseJson3Captions(null)).toEqual([]);
+		expect(parseJson3Captions({ events: [{ tStartMs: 0, aAppend: 1, segs: [{ utf8: "x" }] }] })).toEqual([]);
+	});
+});
+
+describe("normalizeCaptionCase", () => {
+	it("sentence-cases all-caps tracks only", () => {
+		const shouting = [{ timeMs: 0, text: "HELLO WORLD", durationMs: 1 }];
+		expect(normalizeCaptionCase(shouting)[0].text).toBe("Hello world");
+		const mixed = [{ timeMs: 0, text: "Hello WORLD", durationMs: 1 }];
+		expect(normalizeCaptionCase(mixed)[0].text).toBe("Hello WORLD");
+	});
+});
+
+describe("searchYouTubeCaptions", () => {
+	const payload = {
+		events: [
+			{ tStartMs: 100, dDurationMs: 1000, segs: [{ utf8: "first" }] },
+			{ tStartMs: 2000, dDurationMs: 1000, segs: [{ utf8: "second" }] },
+		],
+	};
+
+	it("returns line-synced lyrics for the current video", async () => {
+		const fetchJson = vi.fn(async (_url: string, _signal: AbortSignal) => payload);
+		const result = await searchYouTubeCaptions(info, {
+			loadTracks: async () => ({ videoId: "vid1", tracks: [track({})] }),
+			fetchJson,
+		});
+		expect(result).toMatchObject({ provider: "youtube-captions", syncLevel: "line", hasWordSync: false, artists: ["Artist", "Friend"] });
+		expect(result?.lines?.map((l) => l.text)).toEqual(["first", "second"]);
+		expect(new URL(String(fetchJson.mock.calls[0]?.[0])).searchParams.get("fmt")).toBe("json3");
+	});
+
+	it("refuses captions that belong to a different video (prefetch / race)", async () => {
+		const fetchJson = vi.fn(async () => payload);
+		const result = await searchYouTubeCaptions(
+			{ ...info, videoId: "other" },
+			{ loadTracks: async () => ({ videoId: "vid1", tracks: [track({})] }), fetchJson },
+		);
+		expect(result).toBeNull();
+		expect(fetchJson).not.toHaveBeenCalled();
+	});
+
+	it("treats an empty body / too few lines as a miss", async () => {
+		const result = await searchYouTubeCaptions(info, {
+			loadTracks: async () => ({ videoId: "vid1", tracks: [track({})] }),
+			fetchJson: async () => null,
+		});
+		expect(result).toBeNull();
+	});
+});

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/youtube-captions.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/providers/youtube-captions.ts
@@ -1,0 +1,157 @@
+import { lyricsPage } from "../../lyrics.page";
+import type { LyricLine, LyricResult, LyricWord, TrackSearchInfo, YouTubeCaptionTrack, YouTubeCaptionTracks } from "../types";
+
+/**
+ * YouTube's own caption track on the current video, as a last-resort line-synced source.
+ * Only music videos / live sessions with a human-made caption track qualify — auto-generated (ASR)
+ * captions mishear sung lyrics badly, so they are ignored (same call the Better Lyrics extension makes).
+ */
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MIN_LINES = 2;
+/** Cue text that is a sound cue, not a lyric: `[Music]`, `(applause)`, `♪`. */
+const NON_LYRIC_RE = /^[\s♪♫𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲[\]()]*$|^\s*[[(][^\])]*[\])]\s*$/u;
+const NOTE_EDGES_RE = /^[\s♪♫𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲]+|[\s♪♫𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲]+$/gu;
+
+export interface YouTubeCaptionsSearchOptions {
+	signal?: AbortSignal;
+	/** Injectable for tests; defaults to the page bridge. */
+	loadTracks?: () => Promise<YouTubeCaptionTracks | null>;
+	fetchJson?: (url: string, signal: AbortSignal) => Promise<unknown>;
+}
+
+/** `fmt=json3` payload (only the fields we use). */
+interface Json3Event {
+	tStartMs?: number;
+	dDurationMs?: number;
+	/** Rolling-caption append marker (ASR); such events are continuations, not new lines. */
+	aAppend?: number;
+	segs?: { utf8?: string; tOffsetMs?: number }[];
+}
+
+function baseLang(code: string): string {
+	return code.toLowerCase().split(/[-_]/)[0];
+}
+
+/**
+ * Pick the human-made track that most likely holds the sung lyrics:
+ * same language as the ASR track (the video's spoken language) → first non-translated → first manual.
+ */
+export function pickCaptionTrack(tracks: YouTubeCaptionTrack[]): YouTubeCaptionTrack | null {
+	const manual = tracks.filter((t) => !t.isAuto);
+	if (!manual.length) return null;
+	const spoken = tracks.find((t) => t.isAuto)?.languageCode;
+	if (spoken) {
+		const match = manual.find((t) => baseLang(t.languageCode) === baseLang(spoken));
+		if (match) return match;
+	}
+	return manual[0];
+}
+
+function cleanCueText(raw: string): string {
+	return raw.replace(/\n+/g, " ").replace(NOTE_EDGES_RE, "").replace(/\s+/g, " ").trim();
+}
+
+/** Convert `fmt=json3` events to timed lines; per-segment offsets (when present) become word cues. */
+export function parseJson3Captions(payload: unknown): LyricLine[] {
+	const events = (payload as { events?: Json3Event[] } | null)?.events;
+	if (!Array.isArray(events)) return [];
+
+	const lines: LyricLine[] = [];
+	for (const ev of events) {
+		if (!ev || typeof ev.tStartMs !== "number" || !Array.isArray(ev.segs) || ev.aAppend) continue;
+		const startMs = ev.tStartMs;
+		const durationMs = typeof ev.dDurationMs === "number" && ev.dDurationMs > 0 ? ev.dDurationMs : Number.POSITIVE_INFINITY;
+
+		const segs = ev.segs.filter((s) => typeof s?.utf8 === "string");
+		const text = cleanCueText(segs.map((s) => s.utf8).join(""));
+		if (!text || NON_LYRIC_RE.test(text)) continue;
+
+		// Per-segment offsets (first seg is implicitly at +0) give word cues; otherwise the cue is one line.
+		const timed = segs.length > 1 && segs.slice(1).every((s) => typeof s.tOffsetMs === "number");
+		const words: LyricWord[] = [];
+		if (timed) {
+			for (let i = 0; i < segs.length; i++) {
+				const wordText = String(segs[i].utf8).replace(/\n/g, " ");
+				if (!wordText.trim() && i < segs.length - 1) continue;
+				const wordStart = startMs + (segs[i].tOffsetMs ?? 0);
+				const wordEnd = segs[i + 1] ? startMs + (segs[i + 1].tOffsetMs ?? 0) : Number.isFinite(durationMs) ? startMs + durationMs : wordStart;
+				words.push({ timeMs: wordStart, text: wordText, durationMs: Math.max(0, wordEnd - wordStart) });
+			}
+		}
+
+		lines.push({ timeMs: startMs, text, durationMs, ...(words.length > 1 ? { words } : {}) });
+	}
+
+	lines.sort((a, b) => a.timeMs - b.timeMs);
+	for (let i = 0; i < lines.length; i++) {
+		if (Number.isFinite(lines[i].durationMs)) continue;
+		const next = lines[i + 1];
+		lines[i].durationMs = next ? Math.max(0, next.timeMs - lines[i].timeMs) : Number.POSITIVE_INFINITY;
+	}
+	if (lines[0] && lines[0].timeMs > 300) {
+		lines.unshift({ timeMs: 0, text: "", durationMs: lines[0].timeMs });
+	}
+	return lines;
+}
+
+/** ALL-CAPS caption tracks are common on MVs; sentence-case them so they don't shout. */
+export function normalizeCaptionCase(lines: LyricLine[]): LyricLine[] {
+	const textual = lines.filter((l) => l.text.trim());
+	const letters = textual.map((l) => l.text).join("");
+	if (!/[a-z]/i.test(letters) || letters !== letters.toUpperCase()) return lines;
+	const sentence = (s: string) => (s ? s[0].toUpperCase() + s.slice(1).toLowerCase() : s);
+	return lines.map((l) => ({
+		...l,
+		text: sentence(l.text),
+		...(l.words ? { words: l.words.map((w, i) => ({ ...w, text: i === 0 ? sentence(w.text) : w.text.toLowerCase() })) } : {}),
+	}));
+}
+
+async function defaultLoadTracks(): Promise<YouTubeCaptionTracks | null> {
+	try {
+		return await lyricsPage.request("captionTracks");
+	} catch {
+		return null;
+	}
+}
+
+async function defaultFetchJson(url: string, signal: AbortSignal): Promise<unknown> {
+	const res = await fetch(url, { signal, credentials: "include" });
+	if (!res.ok) throw new Error(`YouTube captions HTTP ${res.status}`);
+	const body = await res.text();
+	// Empty body = signature expired / proof-of-origin gate; treat as a miss, not a parse crash.
+	return body ? JSON.parse(body) : null;
+}
+
+export async function searchYouTubeCaptions(
+	info: TrackSearchInfo,
+	options: YouTubeCaptionsSearchOptions = {},
+): Promise<LyricResult | null> {
+	const loaded = await (options.loadTracks ?? defaultLoadTracks)();
+	// The player only knows the current video — never attribute its captions to a different track.
+	if (!loaded || loaded.videoId !== info.videoId || !loaded.tracks.length) return null;
+
+	const track = pickCaptionTrack(loaded.tracks);
+	if (!track) return null;
+
+	const url = new URL(track.url);
+	url.searchParams.set("fmt", "json3");
+
+	const signals = [AbortSignal.timeout(FETCH_TIMEOUT_MS), ...(options.signal ? [options.signal] : [])];
+	const payload = await (options.fetchJson ?? defaultFetchJson)(url.toString(), AbortSignal.any(signals));
+
+	const lines = normalizeCaptionCase(parseJson3Captions(payload));
+	if (lines.filter((l) => l.text.trim()).length < MIN_LINES) return null;
+	const hasWordSync = lines.some((l) => !!l.words?.length);
+
+	return {
+		title: info.title,
+		artists: info.artist.split(/[&,]/).map((s) => s.trim()).filter(Boolean),
+		lines,
+		inexact: false,
+		provider: "youtube-captions",
+		hasWordSync,
+		syncLevel: hasWordSync ? "word" : "line",
+	};
+}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/store.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/store.ts
@@ -15,6 +15,7 @@ export interface LyricsFetchOptions {
 	showEvenIfInexact: boolean;
 	providers?: unknown;
 	betterLyricsApiKey?: string;
+	preferWordSync?: boolean;
 }
 
 interface CacheEntry {

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/store.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/store.ts
@@ -1,12 +1,25 @@
-import { searchLyrics } from "./providers/search";
+import { searchLyricsDetailed } from "./providers/search";
 import { resolveLyricsDisplay, setLyricsTabDisplayMode, ytmHasStockLyrics } from "./stock";
-import type { LyricResult, LyricsStatus, TrackSearchInfo } from "./types";
+import type { LyricResult, LyricsMissReason, LyricsStatus, TrackSearchInfo } from "./types";
 
 export interface LyricsStoreSnapshot {
 	status: LyricsStatus;
 	result: LyricResult | null;
 	videoId: string | null;
 	errorMessage?: string;
+	/** Why Better Lyrics came back empty (only meaningful when `status === "empty"`). */
+	betterLyricsMiss?: LyricsMissReason;
+}
+
+export interface LyricsFetchOptions {
+	showEvenIfInexact: boolean;
+	providers?: unknown;
+	betterLyricsApiKey?: string;
+}
+
+interface CacheEntry {
+	result: LyricResult | null;
+	betterLyricsMiss?: LyricsMissReason;
 }
 
 type Listener = (snap: LyricsStoreSnapshot) => void;
@@ -20,13 +33,23 @@ function applyDisplay(snap: LyricsStoreSnapshot): LyricsStoreSnapshot {
 	});
 	setLyricsTabDisplayMode(resolved.mode);
 	if (resolved.status === "stock") {
-		return { ...snap, status: "stock", errorMessage: undefined };
+		return { ...snap, status: "stock", errorMessage: undefined, betterLyricsMiss: undefined };
 	}
 	return snap;
 }
 
+function snapFromEntry(entry: CacheEntry, videoId: string): LyricsStoreSnapshot {
+	return {
+		status: entry.result ? "ready" : "empty",
+		result: entry.result,
+		videoId,
+		errorMessage: undefined,
+		betterLyricsMiss: entry.result ? undefined : entry.betterLyricsMiss,
+	};
+}
+
 export function createLyricsStore() {
-	const cache = new Map<string, LyricResult | null>();
+	const cache = new Map<string, CacheEntry>();
 	let abort: AbortController | null = null;
 	let prefetchAbort: AbortController | null = null;
 	let generation = 0;
@@ -67,7 +90,7 @@ export function createLyricsStore() {
 			generation += 1;
 			cache.clear();
 			setLyricsTabDisplayMode("overlay");
-			snap = { status: "idle", result: null, videoId: null, errorMessage: undefined };
+			snap = { status: "idle", result: null, videoId: null, errorMessage: undefined, betterLyricsMiss: undefined };
 			emit();
 		},
 		clearCache() {
@@ -82,6 +105,7 @@ export function createLyricsStore() {
 				result: null,
 				videoId,
 				errorMessage: reason,
+				betterLyricsMiss: undefined,
 			});
 		},
 		/** Show loading while waiting for player meta after trackId:change. */
@@ -94,60 +118,44 @@ export function createLyricsStore() {
 				result: null,
 				videoId,
 				errorMessage: undefined,
+				betterLyricsMiss: undefined,
 			});
 		},
 		/** If lyrics already cached for videoId, apply immediately (skip loading wait). */
 		applyCacheIfPresent(videoId: string): boolean {
-			if (!cache.has(videoId)) return false;
-			const cached = cache.get(videoId) ?? null;
+			const cached = cache.get(videoId);
+			if (!cached) return false;
 			abort?.abort();
 			abort = null;
 			generation += 1;
-			setSnap({
-				status: cached ? "ready" : "empty",
-				result: cached,
-				videoId,
-				errorMessage: undefined,
-			});
+			setSnap(snapFromEntry(cached, videoId));
 			return true;
 		},
 		/**
 		 * Background-fetch lyrics into cache. Does not touch UI snapshot.
 		 * Safe to call for queue "up next" while current track is showing.
 		 */
-		prefetchForTrack(
-			info: TrackSearchInfo,
-			options: { showEvenIfInexact: boolean; providers?: unknown },
-		): void {
+		prefetchForTrack(info: TrackSearchInfo, options: LyricsFetchOptions): void {
 			if (!info.videoId || cache.has(info.videoId)) return;
 			stopPrefetch();
 			prefetchAbort = new AbortController();
 			const signal = prefetchAbort.signal;
-			void searchLyrics(info, {
-				showEvenIfInexact: options.showEvenIfInexact,
-				providers: options.providers,
-				signal,
-			})
-				.then((result) => {
-					if (signal.aborted) return;
-					if (!cache.has(info.videoId)) cache.set(info.videoId, result);
+			void searchLyricsDetailed(info, { ...options, signal, prefetch: true })
+				.then((outcome) => {
+					if (signal.aborted || cache.has(info.videoId)) return;
+					// A partial prefetch (current-video-only providers skipped) is only trustworthy on a timed hit;
+					// otherwise let the real fetch run the full chain when the track actually plays.
+					if (outcome.partial && !outcome.result?.lines?.length) return;
+					cache.set(info.videoId, outcome);
 				})
 				.catch(() => {
 					/* prefetch failures stay silent */
 				});
 		},
-		async fetchForTrack(
-			info: TrackSearchInfo,
-			options: { showEvenIfInexact: boolean; providers?: unknown },
-		): Promise<void> {
+		async fetchForTrack(info: TrackSearchInfo, options: LyricsFetchOptions): Promise<void> {
 			const cached = cache.get(info.videoId);
-			if (cached !== undefined) {
-				setSnap({
-					status: cached ? "ready" : "empty",
-					result: cached,
-					videoId: info.videoId,
-					errorMessage: undefined,
-				});
+			if (cached) {
+				setSnap(snapFromEntry(cached, info.videoId));
 				return;
 			}
 
@@ -155,22 +163,19 @@ export function createLyricsStore() {
 			abort = new AbortController();
 			const gen = ++generation;
 			const signal = abort.signal;
-			setSnap({ status: "loading", result: null, videoId: info.videoId, errorMessage: undefined });
+			setSnap({
+				status: "loading",
+				result: null,
+				videoId: info.videoId,
+				errorMessage: undefined,
+				betterLyricsMiss: undefined,
+			});
 
 			try {
-				const result = await searchLyrics(info, {
-					showEvenIfInexact: options.showEvenIfInexact,
-					providers: options.providers,
-					signal,
-				});
+				const outcome = await searchLyricsDetailed(info, { ...options, signal });
 				if (gen !== generation) return;
-				cache.set(info.videoId, result);
-				setSnap({
-					status: result ? "ready" : "empty",
-					result,
-					videoId: info.videoId,
-					errorMessage: undefined,
-				});
+				cache.set(info.videoId, outcome);
+				setSnap(snapFromEntry(outcome, info.videoId));
 			} catch (err) {
 				if (signal.aborted || gen !== generation) return;
 				const message = err instanceof Error ? err.message : String(err);
@@ -179,6 +184,7 @@ export function createLyricsStore() {
 					result: null,
 					videoId: info.videoId,
 					errorMessage: message,
+					betterLyricsMiss: undefined,
 				});
 			}
 		},

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
@@ -165,11 +165,15 @@
 	overflow: hidden;
 	user-select: none;
 	-webkit-user-select: none;
-	transition: opacity 200ms ease, background-color 200ms ease;
+	/* Ease-out so the hand-off between lines settles instead of snapping. */
+	transition:
+		opacity 420ms cubic-bezier(0.22, 1, 0.36, 1),
+		background-color 420ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-line:hover {
 	opacity: 0.72;
+	transition-duration: 160ms;
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-line.is-active {
@@ -181,8 +185,8 @@
 	background-color: rgba(255, 255, 255, 0.08);
 }
 
-/* Keep the original row progress when dynamic text highlighting is disabled. */
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active.has-line-progress:not(.is-dynamic) {
+/* Line style "bar": row background that advances with playback (line-only cues). */
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active.line-bar {
 	background-color: transparent;
 	background-image: linear-gradient(
 		to right,
@@ -208,7 +212,7 @@
 	overflow-wrap: break-word;
 	word-break: normal;
 	transform-origin: left center;
-	transition: transform 250ms ease;
+	transition: transform 480ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-line.is-dynamic:not(.is-active) .ytmd-lyrics-line-content {
@@ -240,6 +244,7 @@
 	display: inline;
 	color: inherit;
 	-webkit-text-fill-color: inherit;
+	transition: opacity 180ms ease;
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word {
@@ -260,6 +265,20 @@
 		to right,
 		#fff var(--ytmd-word-progress, 0%),
 		rgba(255, 255, 255, 0.35) var(--ytmd-word-progress, 0%)
+	);
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent !important;
+}
+
+/* Line style "fill": text colour that advances with playback (line-only cues). */
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active.line-fill .ytmd-lyrics-text {
+	background-image: linear-gradient(
+		to right,
+		#fff 0%,
+		#fff calc(var(--ytmd-line-progress, 0) * 100%),
+		rgba(255, 255, 255, 0.35) calc(var(--ytmd-line-progress, 0) * 100%),
+		rgba(255, 255, 255, 0.35) 100%
 	);
 	background-clip: text;
 	-webkit-background-clip: text;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
@@ -179,10 +179,13 @@
 #ytmd-lyrics-root .ytmd-lyrics-line.is-active {
 	opacity: 1;
 	font-weight: 600 !important;
+	background-color: rgba(255, 255, 255, 0.08);
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) {
-	background-color: rgba(255, 255, 255, 0.08);
+/* "Active line background" off: only the text brightens. The bar style keeps its row gradient
+ * since that is the indicator the user asked for. */
+#ytmd-lyrics-root .ytmd-lyrics-list.text-only .ytmd-lyrics-line.is-active:not(.line-bar) {
+	background-color: transparent;
 }
 
 /* Line style "bar": row background that advances with playback (line-only cues). */
@@ -211,13 +214,6 @@
 	white-space: normal;
 	overflow-wrap: break-word;
 	word-break: normal;
-	transform-origin: left center;
-	transition: transform 480ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-#ytmd-lyrics-root .ytmd-lyrics-line.is-dynamic:not(.is-active) .ytmd-lyrics-line-content {
-	/* Reserve the full-size layout; scaling inactive text never changes wrapping. */
-	transform: scale(0.92);
 }
 
 /* Time | text — wrapped lines stay in text column, not under timecode. */
@@ -247,38 +243,29 @@
 	transition: opacity 180ms ease;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word {
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active .ytmd-lyrics-word {
 	opacity: 0.45;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word.is-sung {
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active .ytmd-lyrics-word.is-sung {
 	opacity: 0.78;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word.is-current {
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active .ytmd-lyrics-word.is-current {
 	opacity: 1;
 	font-weight: 700 !important;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active.is-dynamic .ytmd-lyrics-word {
+/* Line style "fill" on word-synced lines: each word's colour sweeps left → right over its own
+ * duration (--ytmd-word-progress, 0–100%). Sung words sit at 100%, unsung at 0%, so the step
+ * opacities above are replaced by the gradient. */
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active.word-fill .ytmd-lyrics-word {
+	opacity: 1;
+	font-weight: inherit !important;
 	background-image: linear-gradient(
 		to right,
 		#fff var(--ytmd-word-progress, 0%),
 		rgba(255, 255, 255, 0.35) var(--ytmd-word-progress, 0%)
-	);
-	background-clip: text;
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent !important;
-}
-
-/* Line style "fill": text colour that advances with playback (line-only cues). */
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active.line-fill .ytmd-lyrics-text {
-	background-image: linear-gradient(
-		to right,
-		#fff 0%,
-		#fff calc(var(--ytmd-line-progress, 0) * 100%),
-		rgba(255, 255, 255, 0.35) calc(var(--ytmd-line-progress, 0) * 100%),
-		rgba(255, 255, 255, 0.35) 100%
 	);
 	background-clip: text;
 	-webkit-background-clip: text;
@@ -355,11 +342,6 @@
 	}
 
 	#ytmd-lyrics-root .ytmd-lyrics-word {
-		transition: none;
-	}
-
-	#ytmd-lyrics-root .ytmd-lyrics-line-content {
-		transform: none !important;
 		transition: none;
 	}
 }

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
@@ -39,6 +39,14 @@
 	color: #fff;
 }
 
+#ytmd-lyrics-root .ytmd-lyrics-status-hint {
+	margin: 8px auto 0;
+	max-width: 36em;
+	font-size: 12px;
+	line-height: 1.5;
+	opacity: 0.8;
+}
+
 #ytmd-lyrics-root .ytmd-lyrics-loading {
 	display: flex;
 	flex-direction: column;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
@@ -105,7 +105,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
-	gap: 4px;
+	gap: 8px;
 	flex: 1 1 auto;
 	width: 100%;
 	min-width: 0;
@@ -128,7 +128,7 @@
 	min-width: 0;
 	max-width: 100%;
 	margin: 0;
-	padding: 10px 12px;
+	padding: 14px 12px;
 	border: 0;
 	border-radius: 8px;
 	background-color: transparent;
@@ -147,32 +147,34 @@
 	word-break: normal;
 	overflow-wrap: break-word;
 	font-family: "YouTube Sans", Roboto, Arial, sans-serif !important;
-	font-size: 18px !important;
-	font-weight: 400 !important;
+	font-size: clamp(22px, 1.55vw, 28px) !important;
+	font-weight: 600 !important;
 	font-style: normal !important;
 	font-stretch: normal !important;
-	line-height: 1.5 !important;
-	opacity: 0.5;
+	line-height: 1.35 !important;
+	opacity: 0.32;
 	cursor: pointer;
 	overflow: hidden;
 	user-select: none;
 	-webkit-user-select: none;
-	transition: opacity 120ms ease, background-color 120ms ease;
+	transition: opacity 200ms ease, background-color 200ms ease;
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-line:hover {
-	opacity: 0.85;
-	background-color: rgba(255, 255, 255, 0.06);
+	opacity: 0.72;
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-line.is-active {
 	opacity: 1;
 	font-weight: 600 !important;
+}
+
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) {
 	background-color: rgba(255, 255, 255, 0.08);
 }
 
-/* Muted translucent progress as row background (left → right). */
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active.has-line-progress {
+/* Keep the original row progress when dynamic text highlighting is disabled. */
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active.has-line-progress:not(.is-dynamic) {
 	background-color: transparent;
 	background-image: linear-gradient(
 		to right,
@@ -197,6 +199,13 @@
 	white-space: normal;
 	overflow-wrap: break-word;
 	word-break: normal;
+	transform-origin: left center;
+	transition: transform 250ms ease;
+}
+
+#ytmd-lyrics-root .ytmd-lyrics-line.is-dynamic:not(.is-active) .ytmd-lyrics-line-content {
+	/* Reserve the full-size layout; scaling inactive text never changes wrapping. */
+	transform: scale(0.92);
 }
 
 /* Time | text — wrapped lines stay in text column, not under timecode. */
@@ -223,22 +232,44 @@
 	display: inline;
 	color: inherit;
 	-webkit-text-fill-color: inherit;
-	transition: opacity 80ms ease, color 80ms ease;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active .ytmd-lyrics-word {
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word {
 	opacity: 0.45;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active .ytmd-lyrics-word.is-sung {
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word.is-sung {
 	opacity: 0.78;
 }
 
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active .ytmd-lyrics-word.is-current {
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active:not(.is-dynamic) .ytmd-lyrics-word.is-current {
 	opacity: 1;
 	font-weight: 700 !important;
-	color: #fff !important;
-	-webkit-text-fill-color: #fff !important;
+}
+
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active.is-dynamic .ytmd-lyrics-word {
+	background-image: linear-gradient(
+		to right,
+		#fff var(--ytmd-word-progress, 0%),
+		rgba(255, 255, 255, 0.35) var(--ytmd-word-progress, 0%)
+	);
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent !important;
+}
+
+/* Line-synced lyrics use the same typography fill instead of painting the row. */
+#ytmd-lyrics-root .ytmd-lyrics-line.is-active.is-dynamic.has-line-progress .ytmd-lyrics-text {
+	background-image: linear-gradient(
+		to right,
+		#fff 0%,
+		#fff calc(var(--ytmd-line-progress, 0) * 100%),
+		rgba(255, 255, 255, 0.35) calc(var(--ytmd-line-progress, 0) * 100%),
+		rgba(255, 255, 255, 0.35) 100%
+	);
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent !important;
 }
 
 #ytmd-lyrics-root .ytmd-lyrics-parts {
@@ -311,6 +342,11 @@
 	}
 
 	#ytmd-lyrics-root .ytmd-lyrics-word {
+		transition: none;
+	}
+
+	#ytmd-lyrics-root .ytmd-lyrics-line-content {
+		transform: none !important;
 		transition: none;
 	}
 }

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/styles.css
@@ -266,20 +266,6 @@
 	-webkit-text-fill-color: transparent !important;
 }
 
-/* Line-synced lyrics use the same typography fill instead of painting the row. */
-#ytmd-lyrics-root .ytmd-lyrics-line.is-active.is-dynamic.has-line-progress .ytmd-lyrics-text {
-	background-image: linear-gradient(
-		to right,
-		#fff 0%,
-		#fff calc(var(--ytmd-line-progress, 0) * 100%),
-		rgba(255, 255, 255, 0.35) calc(var(--ytmd-line-progress, 0) * 100%),
-		rgba(255, 255, 255, 0.35) 100%
-	);
-	background-clip: text;
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent !important;
-}
-
 #ytmd-lyrics-root .ytmd-lyrics-parts {
 	display: flex;
 	flex-direction: column;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/tab-mount.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/tab-mount.ts
@@ -32,6 +32,16 @@ export function isLyricsTabSelected(): boolean {
 	return header.getAttribute("aria-selected") === "true";
 }
 
+/** Click the YTM Lyrics tab header (no-op when already selected / header missing / disabled). */
+export function selectLyricsTab(): boolean {
+	const header = findLyricsHeader();
+	if (!header) return false;
+	if (header.getAttribute("aria-selected") === "true") return true;
+	if (header.hasAttribute("disabled") || header.getAttribute("aria-disabled") === "true") return false;
+	header.click();
+	return true;
+}
+
 function ensureHost(body: HTMLElement): HTMLElement {
 	let host = body.querySelector(`#${LYRICS_ROOT_ID}`) as HTMLElement | null;
 	if (!host) {

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/types.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/types.ts
@@ -24,7 +24,7 @@ export interface LyricResult {
 	lines?: LyricLine[];
 	plain?: string;
 	inexact?: boolean;
-	provider: "lrclib" | "better-lyrics" | "unison";
+	provider: "lrclib" | "better-lyrics" | "unison" | "youtube-captions";
 	/** True when result includes real word/syllable cues. */
 	hasWordSync?: boolean;
 	syncLevel?: LyricsSyncLevel;
@@ -40,7 +40,28 @@ export interface TrackSearchInfo {
 	isLiveContent?: boolean;
 }
 
+/** One caption track on the current player video, normalized from the page world. */
+export interface YouTubeCaptionTrack {
+	languageCode: string;
+	/** `timedtext` URL (signed by YTM; short-lived). */
+	url: string;
+	/** Auto-generated (ASR) track. */
+	isAuto: boolean;
+	name: string;
+}
+
+export interface YouTubeCaptionTracks {
+	videoId: string;
+	tracks: YouTubeCaptionTrack[];
+}
+
 export type LyricsStatus = "idle" | "loading" | "ready" | "empty" | "error" | "skipped" | "stock";
+
+/**
+ * Why a provider returned nothing. `uncached` / `invalid-key` come from Better Lyrics'
+ * cache-first auth model (401 on a cache miss) and are surfaced as a hint in the empty state.
+ */
+export type LyricsMissReason = "not-found" | "uncached" | "invalid-key" | "rate-limited";
 
 export interface LyricsViewState {
 	status: LyricsStatus;

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
@@ -1,15 +1,16 @@
 import {
+	type CSSProperties,
+	type KeyboardEvent,
 	memo,
+	type ReactNode,
 	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
 	useSyncExternalStore,
-	type CSSProperties,
-	type KeyboardEvent,
-	type ReactNode,
 } from "react";
 import { activeLineIndices, activeWordIndex, primaryActiveLineIndex } from "../lrc";
+import { wordProgress } from "../progress";
 import { lyricsProviderLabel } from "../providers/catalog";
 import type { LyricsStoreSnapshot } from "../store";
 import type { LyricLine, LyricResult, LyricWord } from "../types";
@@ -22,6 +23,7 @@ export interface LyricsShellState {
 	snap: LyricsStoreSnapshot;
 	showTimeCodes: boolean;
 	showProgressBar: boolean;
+	dynamicLyrics: boolean;
 	settingsEpoch: number;
 }
 
@@ -35,6 +37,7 @@ export interface LyricsUiState extends LyricsShellState, LyricsClockState {}
 export interface LyricsUiOptions {
 	showTimeCodes: () => boolean;
 	showProgressBar: () => boolean;
+	dynamicLyrics: () => boolean;
 	onSeek: (timeMs: number) => void;
 }
 
@@ -89,10 +92,11 @@ function lineProgressRatio(line: LyricLine, nowMs: number): number {
 	return Math.min(1, Math.max(0, (nowMs - line.timeMs) / dur));
 }
 
-function lineClassName(isActive: boolean, showProgress: boolean): string {
+function lineClassName(isActive: boolean, showProgress: boolean, dynamicLyrics: boolean): string {
 	const parts = ["ytmd-lyrics-line"];
 	if (isActive) parts.push("is-active");
 	if (isActive && showProgress) parts.push("has-line-progress");
+	if (dynamicLyrics) parts.push("is-dynamic");
 	return parts.join(" ");
 }
 
@@ -115,17 +119,24 @@ function wordClassName(isActiveLine: boolean, wordIdx: number, activeWord: numbe
 interface WordSyncTextProps {
 	words: LyricWord[];
 	isActive: boolean;
-	activeWord: number;
+	timeMs: number;
+	dynamicLyrics: boolean;
 	onSeek: (timeMs: number) => void;
 }
 
-const WordSyncText = memo(function WordSyncText({ words, isActive, activeWord, onSeek }: WordSyncTextProps) {
+const WordSyncText = memo(function WordSyncText({ words, isActive, timeMs, dynamicLyrics, onSeek }: WordSyncTextProps) {
+	const activeWord = isActive ? activeWordIndex(words, timeMs) : -1;
 	return (
 		<span className="ytmd-lyrics-words">
 			{words.map((word, w) => (
 				<span
 					key={`${word.timeMs}-${w}`}
 					className={wordClassName(isActive, w, activeWord)}
+					style={
+						dynamicLyrics
+							? ({ "--ytmd-word-progress": `${(isActive ? wordProgress(word, timeMs) : 0) * 100}%` } as CSSProperties)
+							: undefined
+					}
 					onClick={(ev) => {
 						ev.stopPropagation();
 						onSeek(word.timeMs);
@@ -145,7 +156,8 @@ interface LyricLineRowProps {
 	progress: number | null;
 	showTimeCodes: boolean;
 	words: LyricWord[] | undefined;
-	activeWord: number;
+	timeMs: number;
+	dynamicLyrics: boolean;
 	onSeek: (timeMs: number) => void;
 }
 
@@ -156,7 +168,8 @@ const LyricLineRow = memo(function LyricLineRow({
 	progress,
 	showTimeCodes,
 	words,
-	activeWord,
+	timeMs,
+	dynamicLyrics,
 	onSeek,
 }: LyricLineRowProps) {
 	const parts = line.parts?.filter((p) => p.length > 0);
@@ -175,7 +188,7 @@ const LyricLineRow = memo(function LyricLineRow({
 
 	let textBody: ReactNode;
 	if (words?.length) {
-		textBody = <WordSyncText words={words} isActive={isActive} activeWord={activeWord} onSeek={onSeek} />;
+		textBody = <WordSyncText words={words} isActive={isActive} timeMs={timeMs} dynamicLyrics={dynamicLyrics} onSeek={onSeek} />;
 	} else if (parts && parts.length > 1) {
 		textBody = (
 			<span className="ytmd-lyrics-parts">
@@ -192,7 +205,7 @@ const LyricLineRow = memo(function LyricLineRow({
 
 	return (
 		<div
-			className={lineClassName(isActive, progress != null)}
+			className={lineClassName(isActive, progress != null, dynamicLyrics)}
 			data-index={index}
 			role="listitem"
 			tabIndex={0}
@@ -229,6 +242,7 @@ interface SyncedListProps {
 	result: LyricResult;
 	showTimeCodes: boolean;
 	showProgressBar: boolean;
+	dynamicLyrics: boolean;
 	settingsEpoch: number;
 	videoId: string | null;
 	subscribeClock: (onStoreChange: () => void) => () => void;
@@ -241,6 +255,7 @@ function SyncedList({
 	result,
 	showTimeCodes,
 	showProgressBar,
+	dynamicLyrics,
 	settingsEpoch,
 	videoId,
 	subscribeClock,
@@ -312,6 +327,8 @@ function SyncedList({
 			const pad = Math.max(24, Math.round(list.clientHeight / 2));
 			list.style.paddingTop = `${pad}px`;
 			list.style.paddingBottom = `${pad}px`;
+			lastScrolledActive.current = -1;
+			setCatchUpNonce((n) => n + 1);
 		};
 		applyPad();
 		const ro = new ResizeObserver(applyPad);
@@ -331,7 +348,6 @@ function SyncedList({
 					const words = line.words?.length ? line.words : undefined;
 					const useWords = !!words?.length;
 					const progress = isActive && showProgressBar && !useWords ? lineProgressRatio(line, timeMs) : null;
-					const activeWord = isActive && useWords ? activeWordIndex(words!, timeMs) : -1;
 					return (
 						<LyricLineRow
 							key={`${line.timeMs}-${i}`}
@@ -341,7 +357,8 @@ function SyncedList({
 							progress={progress}
 							showTimeCodes={showTimeCodes}
 							words={words}
-							activeWord={activeWord}
+							timeMs={isActive && useWords ? timeMs : 0}
+							dynamicLyrics={dynamicLyrics}
 							onSeek={onSeek}
 						/>
 					);
@@ -353,7 +370,7 @@ function SyncedList({
 
 export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, onSeek }: LyricsAppProps) {
 	const shell = useSyncExternalStore(subscribeShell, getShell, getShell);
-	const { snap, showTimeCodes, showProgressBar, settingsEpoch } = shell;
+	const { snap, showTimeCodes, showProgressBar, dynamicLyrics, settingsEpoch } = shell;
 
 	const result = snap.result;
 	const lines = snap.status === "ready" && result?.lines?.length ? result.lines : null;
@@ -387,6 +404,7 @@ export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, 
 				result={result}
 				showTimeCodes={showTimeCodes}
 				showProgressBar={showProgressBar}
+				dynamicLyrics={dynamicLyrics}
 				settingsEpoch={settingsEpoch}
 				videoId={snap.videoId}
 				subscribeClock={subscribeClock}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
@@ -9,6 +9,7 @@ import {
 	useState,
 	useSyncExternalStore,
 } from "react";
+import type { LyricsLineStyle } from "../line-style";
 import { activeLineIndices, activeWordIndex, primaryActiveLineIndex } from "../lrc";
 import { wordProgress } from "../progress";
 import { lyricsProviderLabel } from "../providers/catalog";
@@ -22,7 +23,7 @@ export const USER_SCROLL_PAUSE_MS = 2500;
 export interface LyricsShellState {
 	snap: LyricsStoreSnapshot;
 	showTimeCodes: boolean;
-	showProgressBar: boolean;
+	lineStyle: LyricsLineStyle;
 	dynamicLyrics: boolean;
 	settingsEpoch: number;
 }
@@ -36,7 +37,7 @@ export interface LyricsUiState extends LyricsShellState, LyricsClockState {}
 
 export interface LyricsUiOptions {
 	showTimeCodes: () => boolean;
-	showProgressBar: () => boolean;
+	lineStyle: () => LyricsLineStyle;
 	dynamicLyrics: () => boolean;
 	onSeek: (timeMs: number) => void;
 }
@@ -110,10 +111,11 @@ function lineProgressRatio(line: LyricLine, nowMs: number): number {
 	return Math.min(1, Math.max(0, (nowMs - line.timeMs) / dur));
 }
 
-function lineClassName(isActive: boolean, showProgress: boolean, dynamicLyrics: boolean): string {
+function lineClassName(isActive: boolean, progressStyle: LyricsLineStyle | null, dynamicLyrics: boolean): string {
 	const parts = ["ytmd-lyrics-line"];
 	if (isActive) parts.push("is-active");
-	if (isActive && showProgress) parts.push("has-line-progress");
+	if (isActive && progressStyle === "bar") parts.push("line-bar");
+	if (isActive && progressStyle === "fill") parts.push("line-fill");
 	if (dynamicLyrics) parts.push("is-dynamic");
 	return parts.join(" ");
 }
@@ -171,7 +173,9 @@ interface LyricLineRowProps {
 	line: LyricLine;
 	index: number;
 	isActive: boolean;
+	/** 0..1 playback ratio for line-only cues; null when no progress indicator should draw. */
 	progress: number | null;
+	lineStyle: LyricsLineStyle;
 	showTimeCodes: boolean;
 	words: LyricWord[] | undefined;
 	timeMs: number;
@@ -184,6 +188,7 @@ const LyricLineRow = memo(function LyricLineRow({
 	index,
 	isActive,
 	progress,
+	lineStyle,
 	showTimeCodes,
 	words,
 	timeMs,
@@ -223,7 +228,7 @@ const LyricLineRow = memo(function LyricLineRow({
 
 	return (
 		<div
-			className={lineClassName(isActive, progress != null, dynamicLyrics)}
+			className={lineClassName(isActive, progress != null ? lineStyle : null, dynamicLyrics)}
 			data-index={index}
 			role="listitem"
 			tabIndex={0}
@@ -259,7 +264,7 @@ interface SyncedListProps {
 	lines: LyricLine[];
 	result: LyricResult;
 	showTimeCodes: boolean;
-	showProgressBar: boolean;
+	lineStyle: LyricsLineStyle;
 	dynamicLyrics: boolean;
 	settingsEpoch: number;
 	videoId: string | null;
@@ -272,7 +277,7 @@ function SyncedList({
 	lines,
 	result,
 	showTimeCodes,
-	showProgressBar,
+	lineStyle,
 	dynamicLyrics,
 	settingsEpoch,
 	videoId,
@@ -365,10 +370,10 @@ function SyncedList({
 					const isActive = activeSet.has(i);
 					const words = line.words?.length ? line.words : undefined;
 					const useWords = !!words?.length;
-					// Line-only cues carry no per-word pacing, so a constant-rate fill drifts from the vocal;
-					// in dynamic mode the active line just lights up and scales instead.
+					// Line-only cues carry no per-word pacing, so any progress indicator runs at a constant
+					// rate and can drift from the vocal — it's opt-in via lineStyle ("highlight" draws none).
 					const progress =
-						isActive && showProgressBar && !useWords && !dynamicLyrics ? lineProgressRatio(line, timeMs) : null;
+						isActive && !useWords && lineStyle !== "highlight" ? lineProgressRatio(line, timeMs) : null;
 					return (
 						<LyricLineRow
 							key={`${line.timeMs}-${i}`}
@@ -376,6 +381,7 @@ function SyncedList({
 							index={i}
 							isActive={isActive}
 							progress={progress}
+							lineStyle={lineStyle}
 							showTimeCodes={showTimeCodes}
 							words={words}
 							timeMs={isActive && useWords ? timeMs : 0}
@@ -391,7 +397,7 @@ function SyncedList({
 
 export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, onSeek }: LyricsAppProps) {
 	const shell = useSyncExternalStore(subscribeShell, getShell, getShell);
-	const { snap, showTimeCodes, showProgressBar, dynamicLyrics, settingsEpoch } = shell;
+	const { snap, showTimeCodes, lineStyle, dynamicLyrics, settingsEpoch } = shell;
 
 	const result = snap.result;
 	const lines = snap.status === "ready" && result?.lines?.length ? result.lines : null;
@@ -426,7 +432,7 @@ export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, 
 				lines={lines}
 				result={result}
 				showTimeCodes={showTimeCodes}
-				showProgressBar={showProgressBar}
+				lineStyle={lineStyle}
 				dynamicLyrics={dynamicLyrics}
 				settingsEpoch={settingsEpoch}
 				videoId={snap.videoId}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
@@ -365,7 +365,10 @@ function SyncedList({
 					const isActive = activeSet.has(i);
 					const words = line.words?.length ? line.words : undefined;
 					const useWords = !!words?.length;
-					const progress = isActive && showProgressBar && !useWords ? lineProgressRatio(line, timeMs) : null;
+					// Line-only cues carry no per-word pacing, so a constant-rate fill drifts from the vocal;
+					// in dynamic mode the active line just lights up and scales instead.
+					const progress =
+						isActive && showProgressBar && !useWords && !dynamicLyrics ? lineProgressRatio(line, timeMs) : null;
 					return (
 						<LyricLineRow
 							key={`${line.timeMs}-${i}`}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
@@ -23,8 +23,8 @@ export const USER_SCROLL_PAUSE_MS = 2500;
 export interface LyricsShellState {
 	snap: LyricsStoreSnapshot;
 	showTimeCodes: boolean;
+	lineBackground: boolean;
 	lineStyle: LyricsLineStyle;
-	dynamicLyrics: boolean;
 	settingsEpoch: number;
 }
 
@@ -37,8 +37,8 @@ export interface LyricsUiState extends LyricsShellState, LyricsClockState {}
 
 export interface LyricsUiOptions {
 	showTimeCodes: () => boolean;
+	lineBackground: () => boolean;
 	lineStyle: () => LyricsLineStyle;
-	dynamicLyrics: () => boolean;
 	onSeek: (timeMs: number) => void;
 }
 
@@ -111,12 +111,11 @@ function lineProgressRatio(line: LyricLine, nowMs: number): number {
 	return Math.min(1, Math.max(0, (nowMs - line.timeMs) / dur));
 }
 
-function lineClassName(isActive: boolean, progressStyle: LyricsLineStyle | null, dynamicLyrics: boolean): string {
+function lineClassName(isActive: boolean, progressStyle: LyricsLineStyle | null, wordFill: boolean): string {
 	const parts = ["ytmd-lyrics-line"];
 	if (isActive) parts.push("is-active");
 	if (isActive && progressStyle === "bar") parts.push("line-bar");
-	if (isActive && progressStyle === "fill") parts.push("line-fill");
-	if (dynamicLyrics) parts.push("is-dynamic");
+	if (isActive && wordFill) parts.push("word-fill");
 	return parts.join(" ");
 }
 
@@ -139,13 +138,13 @@ function wordClassName(isActiveLine: boolean, wordIdx: number, activeWord: numbe
 interface WordSyncTextProps {
 	words: LyricWord[];
 	isActive: boolean;
-	timeMs: number;
-	dynamicLyrics: boolean;
+	activeWord: number;
+	/** Playback time for the "fill" sweep; null = step per word only (no per-frame re-render). */
+	fillTimeMs: number | null;
 	onSeek: (timeMs: number) => void;
 }
 
-const WordSyncText = memo(function WordSyncText({ words, isActive, timeMs, dynamicLyrics, onSeek }: WordSyncTextProps) {
-	const activeWord = isActive ? activeWordIndex(words, timeMs) : -1;
+const WordSyncText = memo(function WordSyncText({ words, isActive, activeWord, fillTimeMs, onSeek }: WordSyncTextProps) {
 	return (
 		<span className="ytmd-lyrics-words">
 			{words.map((word, w) => (
@@ -153,8 +152,8 @@ const WordSyncText = memo(function WordSyncText({ words, isActive, timeMs, dynam
 					key={`${word.timeMs}-${w}`}
 					className={wordClassName(isActive, w, activeWord)}
 					style={
-						dynamicLyrics
-							? ({ "--ytmd-word-progress": `${(isActive ? wordProgress(word, timeMs) : 0) * 100}%` } as CSSProperties)
+						fillTimeMs != null
+							? ({ "--ytmd-word-progress": `${wordProgress(word, fillTimeMs) * 100}%` } as CSSProperties)
 							: undefined
 					}
 					onClick={(ev) => {
@@ -178,8 +177,9 @@ interface LyricLineRowProps {
 	lineStyle: LyricsLineStyle;
 	showTimeCodes: boolean;
 	words: LyricWord[] | undefined;
-	timeMs: number;
-	dynamicLyrics: boolean;
+	activeWord: number;
+	/** Playback time while the "fill" sweep is running on this line; null otherwise. */
+	fillTimeMs: number | null;
 	onSeek: (timeMs: number) => void;
 }
 
@@ -191,8 +191,8 @@ const LyricLineRow = memo(function LyricLineRow({
 	lineStyle,
 	showTimeCodes,
 	words,
-	timeMs,
-	dynamicLyrics,
+	activeWord,
+	fillTimeMs,
 	onSeek,
 }: LyricLineRowProps) {
 	const parts = line.parts?.filter((p) => p.length > 0);
@@ -211,7 +211,9 @@ const LyricLineRow = memo(function LyricLineRow({
 
 	let textBody: ReactNode;
 	if (words?.length) {
-		textBody = <WordSyncText words={words} isActive={isActive} timeMs={timeMs} dynamicLyrics={dynamicLyrics} onSeek={onSeek} />;
+		textBody = (
+			<WordSyncText words={words} isActive={isActive} activeWord={activeWord} fillTimeMs={fillTimeMs} onSeek={onSeek} />
+		);
 	} else if (parts && parts.length > 1) {
 		textBody = (
 			<span className="ytmd-lyrics-parts">
@@ -228,7 +230,7 @@ const LyricLineRow = memo(function LyricLineRow({
 
 	return (
 		<div
-			className={lineClassName(isActive, progress != null ? lineStyle : null, dynamicLyrics)}
+			className={lineClassName(isActive, progress != null ? lineStyle : null, fillTimeMs != null)}
 			data-index={index}
 			role="listitem"
 			tabIndex={0}
@@ -264,8 +266,8 @@ interface SyncedListProps {
 	lines: LyricLine[];
 	result: LyricResult;
 	showTimeCodes: boolean;
+	lineBackground: boolean;
 	lineStyle: LyricsLineStyle;
-	dynamicLyrics: boolean;
 	settingsEpoch: number;
 	videoId: string | null;
 	subscribeClock: (onStoreChange: () => void) => () => void;
@@ -277,8 +279,8 @@ function SyncedList({
 	lines,
 	result,
 	showTimeCodes,
+	lineBackground,
 	lineStyle,
-	dynamicLyrics,
 	settingsEpoch,
 	videoId,
 	subscribeClock,
@@ -365,15 +367,22 @@ function SyncedList({
 				<div className="ytmd-lyrics-meta">{providerMetaLabel(result)}</div>
 				{result.inexact ? <div className="ytmd-lyrics-meta">Approximate match</div> : null}
 			</div>
-			<div ref={listRef} className="ytmd-lyrics-list" role="list" onScroll={onListScroll}>
+			<div
+				ref={listRef}
+				className={lineBackground ? "ytmd-lyrics-list" : "ytmd-lyrics-list text-only"}
+				role="list"
+				onScroll={onListScroll}
+			>
 				{lines.map((line, i) => {
 					const isActive = activeSet.has(i);
 					const words = line.words?.length ? line.words : undefined;
 					const useWords = !!words?.length;
-					// Line-only cues carry no per-word pacing, so any progress indicator runs at a constant
-					// rate and can drift from the vocal — it's opt-in via lineStyle ("highlight" draws none).
-					const progress =
-						isActive && !useWords && lineStyle !== "highlight" ? lineProgressRatio(line, timeMs) : null;
+					// "bar" is the only line-only indicator: it runs at a constant rate (line cues carry no
+					// per-word pacing) so it's opt-in. "fill" needs word cues — without them the line just
+					// highlights rather than sweeping at a guessed rate.
+					const progress = isActive && !useWords && lineStyle === "bar" ? lineProgressRatio(line, timeMs) : null;
+					const activeWord = isActive && useWords ? activeWordIndex(words!, timeMs) : -1;
+					const fillTimeMs = isActive && useWords && lineStyle === "fill" ? timeMs : null;
 					return (
 						<LyricLineRow
 							key={`${line.timeMs}-${i}`}
@@ -384,8 +393,8 @@ function SyncedList({
 							lineStyle={lineStyle}
 							showTimeCodes={showTimeCodes}
 							words={words}
-							timeMs={isActive && useWords ? timeMs : 0}
-							dynamicLyrics={dynamicLyrics}
+							activeWord={activeWord}
+							fillTimeMs={fillTimeMs}
 							onSeek={onSeek}
 						/>
 					);
@@ -397,7 +406,7 @@ function SyncedList({
 
 export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, onSeek }: LyricsAppProps) {
 	const shell = useSyncExternalStore(subscribeShell, getShell, getShell);
-	const { snap, showTimeCodes, lineStyle, dynamicLyrics, settingsEpoch } = shell;
+	const { snap, showTimeCodes, lineBackground, lineStyle, settingsEpoch } = shell;
 
 	const result = snap.result;
 	const lines = snap.status === "ready" && result?.lines?.length ? result.lines : null;
@@ -432,8 +441,8 @@ export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, 
 				lines={lines}
 				result={result}
 				showTimeCodes={showTimeCodes}
+				lineBackground={lineBackground}
 				lineStyle={lineStyle}
-				dynamicLyrics={dynamicLyrics}
 				settingsEpoch={settingsEpoch}
 				videoId={snap.videoId}
 				subscribeClock={subscribeClock}

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/LyricsApp.tsx
@@ -69,6 +69,24 @@ export function statusMessage(snap: LyricsStoreSnapshot): string {
 	}
 }
 
+/**
+ * Actionable follow-up for an empty result. Better Lyrics is cache-first: a 401 means the song is
+ * simply not cached yet, which the user can fix themselves (see https://lyrics-api-docs.boidu.dev/docs/authentication).
+ */
+export function statusHint(snap: LyricsStoreSnapshot): string | null {
+	if (snap.status !== "empty") return null;
+	switch (snap.betterLyricsMiss) {
+		case "uncached":
+			return "Better Lyrics hasn't cached this song yet. Play it once with the Better Lyrics browser extension, or add the lyrics on Unison, then replay.";
+		case "invalid-key":
+			return "Better Lyrics rejected the API key set in Settings → Player → Lyrics.";
+		case "rate-limited":
+			return "Better Lyrics is rate-limiting requests right now. Try again in a moment.";
+		default:
+			return null;
+	}
+}
+
 function prefersReducedMotion(): boolean {
 	try {
 		return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -388,10 +406,12 @@ export function LyricsApp({ subscribeShell, getShell, subscribeClock, getClock, 
 	}
 
 	if (snap.status !== "ready" || !result) {
+		const hint = statusHint(snap);
 		return (
 			<div className="ytmd-lyrics-body">
 				<div className="ytmd-lyrics-status" role="status">
 					{statusMessage(snap)}
+					{hint ? <div className="ytmd-lyrics-status-hint">{hint}</div> : null}
 				</div>
 			</div>
 		);

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/render.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/render.ts
@@ -31,8 +31,8 @@ export function createLyricsRenderer(
 	let shell: LyricsShellState = {
 		snap: { status: "idle", result: null, videoId: null },
 		showTimeCodes: options.showTimeCodes(),
+		lineBackground: options.lineBackground(),
 		lineStyle: options.lineStyle(),
-		dynamicLyrics: options.dynamicLyrics(),
 		settingsEpoch: 0,
 	};
 	let clock: LyricsClockState = { timeMs: 0 };
@@ -113,8 +113,8 @@ export function createLyricsRenderer(
 		repaint() {
 			patchShell({
 				showTimeCodes: options.showTimeCodes(),
+				lineBackground: options.lineBackground(),
 				lineStyle: options.lineStyle(),
-				dynamicLyrics: options.dynamicLyrics(),
 				settingsEpoch: shell.settingsEpoch + 1,
 			});
 			ensureRoot();

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/render.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/render.ts
@@ -31,7 +31,7 @@ export function createLyricsRenderer(
 	let shell: LyricsShellState = {
 		snap: { status: "idle", result: null, videoId: null },
 		showTimeCodes: options.showTimeCodes(),
-		showProgressBar: options.showProgressBar(),
+		lineStyle: options.lineStyle(),
 		dynamicLyrics: options.dynamicLyrics(),
 		settingsEpoch: 0,
 	};
@@ -113,7 +113,7 @@ export function createLyricsRenderer(
 		repaint() {
 			patchShell({
 				showTimeCodes: options.showTimeCodes(),
-				showProgressBar: options.showProgressBar(),
+				lineStyle: options.lineStyle(),
 				dynamicLyrics: options.dynamicLyrics(),
 				settingsEpoch: shell.settingsEpoch + 1,
 			});

--- a/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/render.ts
+++ b/apps/ytmdesktop2/src/renderer-plugins/youtube/lyrics/ui/render.ts
@@ -1,12 +1,12 @@
 import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import type { LyricsStoreSnapshot } from "../store";
 import {
 	LyricsApp,
 	type LyricsClockState,
 	type LyricsShellState,
 	type LyricsUiOptions,
 } from "./LyricsApp";
-import type { LyricsStoreSnapshot } from "../store";
 
 export interface LyricsRenderApi {
 	setSnapshot(snap: LyricsStoreSnapshot): void;
@@ -32,6 +32,7 @@ export function createLyricsRenderer(
 		snap: { status: "idle", result: null, videoId: null },
 		showTimeCodes: options.showTimeCodes(),
 		showProgressBar: options.showProgressBar(),
+		dynamicLyrics: options.dynamicLyrics(),
 		settingsEpoch: 0,
 	};
 	let clock: LyricsClockState = { timeMs: 0 };
@@ -113,6 +114,7 @@ export function createLyricsRenderer(
 			patchShell({
 				showTimeCodes: options.showTimeCodes(),
 				showProgressBar: options.showProgressBar(),
+				dynamicLyrics: options.dynamicLyrics(),
 				settingsEpoch: shell.settingsEpoch + 1,
 			});
 			ensureRoot();

--- a/apps/ytmdesktop2/src/renderer/src/components/settings-color.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/components/settings-color.tsx
@@ -1,0 +1,63 @@
+import { joinHexColor, splitHexColor } from "@shared/lyrics/overlay";
+import { type ReactNode, useId } from "react";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import { useSettingsState } from "@/hooks/use-settings";
+import { cn } from "@/lib/utils";
+
+export interface SettingsColorProps {
+	configKey: string;
+	/** `#rrggbb` or `#rrggbbaa`. */
+	defaultValue: string;
+	label?: ReactNode;
+	hint?: ReactNode;
+	className?: string;
+	disabled?: boolean;
+	/** Show the opacity slider (stored as the alpha byte of the same key). */
+	withOpacity?: boolean;
+}
+
+/** Colour picker (+ optional opacity slider) persisted as one `#rrggbb[aa]` string. */
+export function SettingsColor({ configKey, defaultValue, label, hint, className, disabled, withOpacity = true }: SettingsColorProps) {
+	const id = useId();
+	const [value, setValue, { isPending }] = useSettingsState<string>(configKey, defaultValue, { debounce: 200 });
+	const { hex, alpha } = splitHexColor(typeof value === "string" ? value : defaultValue);
+	const percent = Math.round(alpha * 100);
+	const locked = disabled || isPending;
+
+	return (
+		<Field data-disabled={locked || undefined} className={cn(className)}>
+			{label ? <FieldLabel htmlFor={id}>{label}</FieldLabel> : null}
+			<div className="flex items-center gap-3">
+				<Input
+					id={id}
+					type="color"
+					className="h-8 w-12 shrink-0 cursor-pointer p-1"
+					value={hex}
+					disabled={locked}
+					onChange={(ev) => setValue(joinHexColor(ev.target.value, alpha))}
+				/>
+				{withOpacity ? (
+					<>
+						<Slider
+							aria-label="Opacity"
+							min={0}
+							max={100}
+							step={1}
+							disabled={locked}
+							value={[percent]}
+							onValueChange={(next) => {
+								const n = Array.isArray(next) ? next[0] : next;
+								if (typeof n !== "number" || !Number.isFinite(n)) return;
+								setValue(joinHexColor(hex, n / 100));
+							}}
+						/>
+						<span className="w-10 shrink-0 text-right text-xs tabular-nums text-muted-foreground">{percent}%</span>
+					</>
+				) : null}
+			</div>
+			{hint ? <FieldDescription>{hint}</FieldDescription> : null}
+		</Field>
+	);
+}

--- a/apps/ytmdesktop2/src/renderer/src/components/settings-input.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/components/settings-input.tsx
@@ -79,13 +79,13 @@ export function SettingsInput({
 		<Field data-disabled={isPending || undefined} className={cn(className)}>
 			{label ? <FieldLabel htmlFor={id}>{label}</FieldLabel> : null}
 			<Input
+				{...attrs}
 				id={id}
 				type={type}
-				placeholder={attrs.placeholder}
 				value={String(value ?? "")}
 				min={min}
 				max={max}
-				disabled={isPending}
+				disabled={isPending || attrs.disabled}
 				onChange={(ev) => {
 					if (type === "number" && (min !== undefined || max !== undefined)) {
 						const n = Number(ev.target.value);

--- a/apps/ytmdesktop2/src/renderer/src/components/settings-select.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/components/settings-select.tsx
@@ -17,6 +17,7 @@ export interface SettingsSelectProps {
 	description?: ReactNode;
 	options: SettingsSelectOption[];
 	className?: string;
+	disabled?: boolean;
 	onChange?: (value: string) => void;
 }
 
@@ -31,7 +32,16 @@ function OptionContent({ label, description, compact }: { label: ReactNode; desc
 	);
 }
 
-export function SettingsSelect({ configKey, defaultValue = "", label, description, options, className, onChange }: SettingsSelectProps) {
+export function SettingsSelect({
+	configKey,
+	defaultValue = "",
+	label,
+	description,
+	options,
+	className,
+	disabled,
+	onChange,
+}: SettingsSelectProps) {
 	const id = useId();
 	const [value, setValue, { isPending }] = useSettingsState<string>(configKey, defaultValue, { debounce: 200 });
 	const rich = options.some((opt) => opt.description != null);
@@ -43,13 +53,13 @@ export function SettingsSelect({ configKey, defaultValue = "", label, descriptio
 	);
 
 	return (
-		<Field data-disabled={isPending || undefined} className={cn(className)}>
+		<Field data-disabled={isPending || disabled || undefined} className={cn(className)}>
 			{label ? <FieldLabel htmlFor={id}>{label}</FieldLabel> : null}
 			{description ? <FieldDescription>{description}</FieldDescription> : null}
 			<Select
 				value={value}
 				items={items}
-				disabled={isPending}
+				disabled={isPending || disabled}
 				onValueChange={(next) => {
 					if (next == null || next === value) return;
 					setValue(next);
@@ -58,7 +68,7 @@ export function SettingsSelect({ configKey, defaultValue = "", label, descriptio
 			>
 				<SelectTrigger
 					id={id}
-					disabled={isPending}
+					disabled={isPending || disabled}
 					className={cn(
 						"w-full",
 						rich &&

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -15,17 +15,18 @@ const LINE_STYLE_OPTIONS: SettingsSelectOption[] = [
 	{
 		value: "highlight",
 		label: "Highlight only",
-		description: "Light the current line up (and enlarge it with Dynamic lyrics). No progress indicator.",
-	},
-	{
-		value: "bar",
-		label: "Progress bar",
-		description: "A row background that advances across the line as it plays.",
+		description: "Light the current line up. Word-synced lyrics still step word by word; no extra indicator.",
 	},
 	{
 		value: "fill",
 		label: "Text fill",
-		description: "The text turns white from left to right as the line plays.",
+		description:
+			"Word-synced lyrics: each word sweeps to white as it's sung. Songs with line timing only fall back to Highlight only.",
+	},
+	{
+		value: "bar",
+		label: "Progress bar",
+		description: "Songs with line timing only: a row background advances across the line at a constant rate.",
 	},
 ];
 
@@ -59,14 +60,6 @@ function LyricsSettingsPage() {
 							Auto-open Lyrics tab
 						</SettingsCheckbox>
 						<SettingsCheckbox
-							configKey="lyrics.dynamicLyrics"
-							defaultValue={true}
-							disabled={!lyricsEnabled}
-							description="Continuously fill word-synced lyric text as it plays and gently enlarge the current line. Line-synced lyrics follow the Line-synced style below."
-						>
-							Dynamic lyrics
-						</SettingsCheckbox>
-						<SettingsCheckbox
 							configKey="lyrics.preferWordSync"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
@@ -89,12 +82,20 @@ function LyricsSettingsPage() {
 						>
 							Show time codes
 						</SettingsCheckbox>
+						<SettingsCheckbox
+							configKey="lyrics.lineBackground"
+							defaultValue={true}
+							disabled={!lyricsEnabled}
+							description="Tint the row behind the current line. Turn off to brighten the text only. The Progress bar style still draws its bar."
+						>
+							Active line background
+						</SettingsCheckbox>
 						<SettingsSelect
 							configKey="lyrics.lineStyle"
-							defaultValue="highlight"
+							defaultValue="fill"
 							disabled={!lyricsEnabled}
-							label="Line-synced style"
-							description="How the current line shows progress when the provider only has line timing (no word/syllable cues). Line timing says when a line starts, not how fast it's sung, so bar and fill advance at a constant rate."
+							label="Highlight style"
+							description="How the current line shows progress. Text fill needs word/syllable timing from the provider; line timing only says when a line starts, not how fast it's sung, so those songs get a plain highlight or the constant-rate bar."
 							options={LINE_STYLE_OPTIONS}
 						/>
 					</FieldGroup>

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -1,11 +1,15 @@
+import { DEFAULT_LYRICS_OVERLAY_SETTINGS, LYRICS_OVERLAY_FONT_SIZE, LYRICS_OVERLAY_OUTLINE_WIDTH } from "@shared/lyrics/overlay";
 import { createFileRoute } from "@tanstack/react-router";
 import { LyricsProvidersOrder } from "@/components/lyrics-providers-order";
 import { SettingsCheckbox } from "@/components/settings-checkbox";
+import { SettingsColor } from "@/components/settings-color";
 import { SettingsInput } from "@/components/settings-input";
 import { SettingsSelect, type SettingsSelectOption } from "@/components/settings-select";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldGroup } from "@/components/ui/field";
 import { useSettingsState } from "@/hooks/use-settings";
+import { trpc } from "@/lib/trpc";
 
 export const Route = createFileRoute("/_settings/player/lyrics")({
 	component: LyricsSettingsPage,
@@ -29,6 +33,171 @@ const LINE_STYLE_OPTIONS: SettingsSelectOption[] = [
 		description: "Songs with line timing only: a row background advances across the line at a constant rate.",
 	},
 ];
+
+const OVERLAY_ALIGN_OPTIONS: SettingsSelectOption[] = [
+	{ value: "center", label: "Center" },
+	{ value: "left", label: "Left" },
+	{ value: "right", label: "Right" },
+];
+
+function DesktopLyricsCard({ lyricsEnabled }: { lyricsEnabled: boolean }) {
+	const [overlayEnabled] = useSettingsState<boolean>("lyrics.overlay.enabled", DEFAULT_LYRICS_OVERLAY_SETTINGS.enabled);
+	const [lineStyle] = useSettingsState<string>("lyrics.overlay.lineStyle", DEFAULT_LYRICS_OVERLAY_SETTINGS.lineStyle);
+	const [showNextLine] = useSettingsState<boolean>("lyrics.overlay.showNextLine", DEFAULT_LYRICS_OVERLAY_SETTINGS.showNextLine);
+	const [textOutline] = useSettingsState<boolean>("lyrics.overlay.textOutline", DEFAULT_LYRICS_OVERLAY_SETTINGS.textOutline);
+	const [textShadow] = useSettingsState<boolean>("lyrics.overlay.textShadow", DEFAULT_LYRICS_OVERLAY_SETTINGS.textShadow);
+	const { mutate: resetPosition } = trpc.lyrics.resetOverlayPosition.useMutation();
+	const controlsDisabled = !lyricsEnabled || !overlayEnabled;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Desktop lyrics</CardTitle>
+				<CardDescription>
+					A transparent always-on-top window that shows the current line over any app. Drag it anywhere and pull
+					its edges to resize, then lock it so clicks and keys pass straight through to whatever is underneath.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<FieldGroup>
+					<SettingsCheckbox
+						configKey="lyrics.overlay.enabled"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.enabled}
+						disabled={!lyricsEnabled}
+						description="Open the floating lyrics window. Also available from the tray icon menu."
+					>
+						Show desktop lyrics
+					</SettingsCheckbox>
+					<SettingsCheckbox
+						configKey="lyrics.overlay.locked"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.locked}
+						disabled={controlsDisabled}
+						description="Click-through and never focused: the mouse and keyboard ignore the window. Unlock here or from the tray menu to move it again."
+					>
+						Lock position (click-through)
+					</SettingsCheckbox>
+					<SettingsSelect
+						configKey="lyrics.overlay.lineStyle"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.lineStyle}
+						disabled={controlsDisabled}
+						label="Highlight style"
+						description="Same three styles as the in-app Lyrics tab. Text fill needs word/syllable timing; line-only songs fall back to Highlight, or the constant-rate bar."
+						options={LINE_STYLE_OPTIONS}
+					/>
+					<div className="grid gap-4 sm:grid-cols-3">
+						<SettingsInput
+							configKey="lyrics.overlay.fontSize"
+							type="number"
+							min={LYRICS_OVERLAY_FONT_SIZE.min}
+							max={LYRICS_OVERLAY_FONT_SIZE.max}
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.fontSize}
+							disabled={controlsDisabled}
+							label="Font size (px)"
+						/>
+						<SettingsColor
+							configKey="lyrics.overlay.textColor"
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.textColor}
+							disabled={controlsDisabled}
+							withOpacity={false}
+							label="Text colour"
+						/>
+						<SettingsColor
+							configKey="lyrics.overlay.accentColor"
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.accentColor}
+							disabled={controlsDisabled}
+							withOpacity={false}
+							label="Sung / accent colour"
+							hint="Fill sweep, stepped words, and the whole line in Highlight mode (or Text fill on line-only songs)."
+						/>
+					</div>
+					<SettingsSelect
+						configKey="lyrics.overlay.align"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.align}
+						disabled={controlsDisabled}
+						label="Alignment"
+						options={OVERLAY_ALIGN_OPTIONS}
+					/>
+					<SettingsCheckbox
+						configKey="lyrics.overlay.showNextLine"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.showNextLine}
+						disabled={controlsDisabled}
+						description="Draw the upcoming line, smaller, under the current one."
+					>
+						Show next line
+					</SettingsCheckbox>
+					<SettingsColor
+						configKey="lyrics.overlay.nextLineColor"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.nextLineColor}
+						disabled={controlsDisabled || !showNextLine}
+						label="Next line colour and opacity"
+					/>
+					<div className="grid gap-4 sm:grid-cols-2">
+						<SettingsColor
+							configKey="lyrics.overlay.barBackground"
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.barBackground}
+							disabled={controlsDisabled || lineStyle !== "bar"}
+							label="Progress bar background"
+							hint="Unplayed part of the pill behind the current line (Progress bar mode)."
+						/>
+						<SettingsColor
+							configKey="lyrics.overlay.barProgressColor"
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.barProgressColor}
+							disabled={controlsDisabled || lineStyle !== "bar"}
+							label="Progress bar fill"
+							hint="Played part of the pill."
+						/>
+					</div>
+					<SettingsCheckbox
+						configKey="lyrics.overlay.textOutline"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.textOutline}
+						disabled={controlsDisabled}
+						description="Crisp stroke around every glyph so light text stays readable over bright windows."
+					>
+						Text outline
+					</SettingsCheckbox>
+					<div className="grid gap-4 sm:grid-cols-2">
+						<SettingsColor
+							configKey="lyrics.overlay.outlineColor"
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.outlineColor}
+							disabled={controlsDisabled || !textOutline}
+							label="Outline colour"
+						/>
+						<SettingsInput
+							configKey="lyrics.overlay.outlineWidth"
+							type="number"
+							step={0.5}
+							min={LYRICS_OVERLAY_OUTLINE_WIDTH.min}
+							max={LYRICS_OVERLAY_OUTLINE_WIDTH.max}
+							defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.outlineWidth}
+							disabled={controlsDisabled || !textOutline}
+							label="Outline width (px)"
+						/>
+					</div>
+					<SettingsCheckbox
+						configKey="lyrics.overlay.textShadow"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.textShadow}
+						disabled={controlsDisabled}
+						description="Soft drop shadow under the glyphs, separate from the outline."
+					>
+						Text shadow
+					</SettingsCheckbox>
+					<SettingsColor
+						configKey="lyrics.overlay.shadowColor"
+						defaultValue={DEFAULT_LYRICS_OVERLAY_SETTINGS.shadowColor}
+						disabled={controlsDisabled || !textShadow}
+						label="Shadow colour"
+					/>
+				</FieldGroup>
+			</CardContent>
+			<CardFooter className="gap-3">
+				<Button type="button" variant="outline" size="sm" disabled={controlsDisabled} onClick={() => resetPosition()}>
+					Reset position
+				</Button>
+				<p className="text-xs text-muted-foreground">Moves the window back to the bottom of the primary display.</p>
+			</CardFooter>
+		</Card>
+	);
+}
 
 function LyricsSettingsPage() {
 	const [lyricsEnabled] = useSettingsState<boolean>("lyrics.enabled", false);
@@ -101,6 +270,7 @@ function LyricsSettingsPage() {
 					</FieldGroup>
 				</CardContent>
 			</Card>
+			<DesktopLyricsCard lyricsEnabled={lyricsEnabled} />
 			<Card>
 				<CardHeader>
 					<CardTitle>Providers</CardTitle>

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -31,6 +31,14 @@ function LyricsSettingsPage() {
 							Enable lyrics
 						</SettingsCheckbox>
 						<SettingsCheckbox
+							configKey="lyrics.dynamicLyrics"
+							defaultValue={true}
+							disabled={!lyricsEnabled}
+							description="Continuously fill the lyric text as it plays and gently enlarge the current line."
+						>
+							Dynamic lyrics
+						</SettingsCheckbox>
+						<SettingsCheckbox
 							configKey="lyrics.showEvenIfInexact"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
@@ -49,7 +57,7 @@ function LyricsSettingsPage() {
 							configKey="lyrics.showProgressBar"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
-							description="Fill the active lyric row as it plays when the provider has no word/syllable cues."
+							description="Show playback progress on the active line when the provider has no word/syllable cues."
 						>
 							Show line progress
 						</SettingsCheckbox>

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -32,12 +32,28 @@ function LyricsSettingsPage() {
 							Enable lyrics
 						</SettingsCheckbox>
 						<SettingsCheckbox
+							configKey="lyrics.autoOpenTab"
+							defaultValue={true}
+							disabled={!lyricsEnabled}
+							description="Switch the player page to the Lyrics tab when lyrics for a new track are found. Once per track, so switching away by hand sticks."
+						>
+							Auto-open Lyrics tab
+						</SettingsCheckbox>
+						<SettingsCheckbox
 							configKey="lyrics.dynamicLyrics"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
 							description="Continuously fill the lyric text as it plays and gently enlarge the current line."
 						>
 							Dynamic lyrics
+						</SettingsCheckbox>
+						<SettingsCheckbox
+							configKey="lyrics.preferWordSync"
+							defaultValue={true}
+							disabled={!lyricsEnabled}
+							description="Keep trying later providers for word/syllable timing before settling for line-synced lyrics. A few extra requests on line-only songs."
+						>
+							Prefer word-synced sources
 						</SettingsCheckbox>
 						<SettingsCheckbox
 							configKey="lyrics.showEvenIfInexact"

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { LyricsProvidersOrder } from "@/components/lyrics-providers-order";
 import { SettingsCheckbox } from "@/components/settings-checkbox";
+import { SettingsInput } from "@/components/settings-input";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldGroup } from "@/components/ui/field";
 import { useSettingsState } from "@/hooks/use-settings";
@@ -68,12 +69,31 @@ function LyricsSettingsPage() {
 				<CardHeader>
 					<CardTitle>Providers</CardTitle>
 					<CardDescription>
-						Tried in order until one returns lyrics (default: Better Lyrics → Unison → LRCLib). Better Lyrics and Unison
-						can return syllable sync; LRCLib is line/plain only. Toggle sources on or off and drag to reorder.
+						Tried in order until one returns lyrics (default: Better Lyrics → Unison → LRCLib → YouTube captions). Better Lyrics and Unison
+						can return syllable sync; LRCLib is line/plain (word sync when the entry has it); YouTube captions is line-only and
+						uses the current video's own caption track. Toggle sources on or off and drag to reorder.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<LyricsProvidersOrder disabled={!lyricsEnabled} />
+					<FieldGroup>
+						<LyricsProvidersOrder disabled={!lyricsEnabled} />
+						<SettingsInput
+							configKey="lyrics.betterLyricsApiKey"
+							type="password"
+							autoComplete="off"
+							spellCheck={false}
+							disabled={!lyricsEnabled}
+							placeholder="Optional"
+							label="Better Lyrics API key"
+							hint={
+								<>
+									Sent as <code>X-API-Key</code>. Cached songs never need a key; uncached songs do, and Better
+									Lyrics is not issuing new keys right now. Without one, play a song once in the Better Lyrics
+									browser extension to cache it.
+								</>
+							}
+						/>
+					</FieldGroup>
 				</CardContent>
 				<CardFooter>
 					<p className="text-xs text-muted-foreground">Site links open each provider&apos;s homepage or docs.</p>

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { LyricsProvidersOrder } from "@/components/lyrics-providers-order";
 import { SettingsCheckbox } from "@/components/settings-checkbox";
 import { SettingsInput } from "@/components/settings-input";
+import { SettingsSelect, type SettingsSelectOption } from "@/components/settings-select";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldGroup } from "@/components/ui/field";
 import { useSettingsState } from "@/hooks/use-settings";
@@ -9,6 +10,24 @@ import { useSettingsState } from "@/hooks/use-settings";
 export const Route = createFileRoute("/_settings/player/lyrics")({
 	component: LyricsSettingsPage,
 });
+
+const LINE_STYLE_OPTIONS: SettingsSelectOption[] = [
+	{
+		value: "highlight",
+		label: "Highlight only",
+		description: "Light the current line up (and enlarge it with Dynamic lyrics). No progress indicator.",
+	},
+	{
+		value: "bar",
+		label: "Progress bar",
+		description: "A row background that advances across the line as it plays.",
+	},
+	{
+		value: "fill",
+		label: "Text fill",
+		description: "The text turns white from left to right as the line plays.",
+	},
+];
 
 function LyricsSettingsPage() {
 	const [lyricsEnabled] = useSettingsState<boolean>("lyrics.enabled", false);
@@ -43,7 +62,7 @@ function LyricsSettingsPage() {
 							configKey="lyrics.dynamicLyrics"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
-							description="Continuously fill word-synced lyric text as it plays and gently enlarge the current line. Line-synced lyrics just highlight and enlarge."
+							description="Continuously fill word-synced lyric text as it plays and gently enlarge the current line. Line-synced lyrics follow the Line-synced style below."
 						>
 							Dynamic lyrics
 						</SettingsCheckbox>
@@ -70,14 +89,14 @@ function LyricsSettingsPage() {
 						>
 							Show time codes
 						</SettingsCheckbox>
-						<SettingsCheckbox
-							configKey="lyrics.showProgressBar"
-							defaultValue={true}
+						<SettingsSelect
+							configKey="lyrics.lineStyle"
+							defaultValue="highlight"
 							disabled={!lyricsEnabled}
-							description="Show playback progress on the active line when the provider has no word/syllable cues. Only applies when Dynamic lyrics is off."
-						>
-							Show line progress
-						</SettingsCheckbox>
+							label="Line-synced style"
+							description="How the current line shows progress when the provider only has line timing (no word/syllable cues). Line timing says when a line starts, not how fast it's sung, so bar and fill advance at a constant rate."
+							options={LINE_STYLE_OPTIONS}
+						/>
 					</FieldGroup>
 				</CardContent>
 			</Card>

--- a/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/_settings/player/lyrics.tsx
@@ -43,7 +43,7 @@ function LyricsSettingsPage() {
 							configKey="lyrics.dynamicLyrics"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
-							description="Continuously fill the lyric text as it plays and gently enlarge the current line."
+							description="Continuously fill word-synced lyric text as it plays and gently enlarge the current line. Line-synced lyrics just highlight and enlarge."
 						>
 							Dynamic lyrics
 						</SettingsCheckbox>
@@ -74,7 +74,7 @@ function LyricsSettingsPage() {
 							configKey="lyrics.showProgressBar"
 							defaultValue={true}
 							disabled={!lyricsEnabled}
-							description="Show playback progress on the active line when the provider has no word/syllable cues."
+							description="Show playback progress on the active line when the provider has no word/syllable cues. Only applies when Dynamic lyrics is off."
 						>
 							Show line progress
 						</SettingsCheckbox>

--- a/apps/ytmdesktop2/src/renderer/src/routes/lyrics-overlay.tsx
+++ b/apps/ytmdesktop2/src/renderer/src/routes/lyrics-overlay.tsx
@@ -1,0 +1,249 @@
+import { activeWordIndex, primaryActiveLineIndex } from "@plugins/youtube/lyrics/lrc";
+import { wordProgress } from "@plugins/youtube/lyrics/progress";
+import {
+	DEFAULT_LYRICS_OVERLAY_SETTINGS,
+	EMPTY_LYRICS_OVERLAY_SNAPSHOT,
+	type LyricsOverlayClock,
+	type LyricsOverlayLine,
+	type LyricsOverlaySettings,
+	type LyricsOverlaySnapshot,
+	type LyricsOverlayWord,
+	readLyricsOverlaySettings,
+	resolveLyricsOverlayTimeMs,
+} from "@shared/lyrics/overlay";
+import { createFileRoute } from "@tanstack/react-router";
+import { GripHorizontalIcon, LockIcon, Settings2Icon, XIcon } from "lucide-react";
+import { type CSSProperties, memo, useEffect, useMemo, useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { cn } from "@/lib/utils";
+import "@/styles/lyrics-overlay.css";
+
+export const Route = createFileRoute("/lyrics-overlay")({
+	component: LyricsOverlayPage,
+});
+
+const OVERLAY_SETTINGS_KEY = "lyrics.overlay";
+
+/** `lyrics.overlay.*` + `lyrics.enabled`, kept live through the settings change stream. */
+function useOverlaySettings(): { overlay: LyricsOverlaySettings; lyricsEnabled: boolean } {
+	const utils = trpc.useUtils();
+	const overlayInput = useMemo(() => ({ key: OVERLAY_SETTINGS_KEY, defaultValue: DEFAULT_LYRICS_OVERLAY_SETTINGS }), []);
+	const enabledInput = useMemo(() => ({ key: "lyrics.enabled", defaultValue: false }), []);
+	const { data: rawOverlay } = trpc.settings.get.useQuery(overlayInput);
+	const { data: rawEnabled } = trpc.settings.get.useQuery(enabledInput);
+
+	trpc.settings.onChange.useSubscription(undefined, {
+		onData: (ev) => {
+			if (ev.key === "lyrics.enabled") {
+				utils.settings.get.setData(enabledInput, ev.value);
+				return;
+			}
+			if (ev.key === OVERLAY_SETTINGS_KEY) {
+				utils.settings.get.setData(overlayInput, ev.value);
+				return;
+			}
+			if (ev.key.startsWith(`${OVERLAY_SETTINGS_KEY}.`)) {
+				const field = ev.key.slice(OVERLAY_SETTINGS_KEY.length + 1);
+				utils.settings.get.setData(overlayInput, (prev) => ({ ...(prev as object), [field]: ev.value }));
+			}
+		},
+	});
+
+	return {
+		overlay: useMemo(() => readLyricsOverlaySettings(rawOverlay), [rawOverlay]),
+		lyricsEnabled: rawEnabled === true,
+	};
+}
+
+function useOverlayFeed() {
+	const utils = trpc.useUtils();
+	const { data: snapshot } = trpc.lyrics.overlaySnapshot.useQuery();
+	const { data: clock } = trpc.lyrics.overlayClock.useQuery();
+	const { data: state } = trpc.lyrics.overlayState.useQuery();
+
+	trpc.lyrics.onOverlaySnapshot.useSubscription(undefined, {
+		onData: (next) => utils.lyrics.overlaySnapshot.setData(undefined, next as LyricsOverlaySnapshot),
+	});
+	trpc.lyrics.onOverlayClock.useSubscription(undefined, {
+		onData: (next) => utils.lyrics.overlayClock.setData(undefined, next as LyricsOverlayClock),
+	});
+	trpc.lyrics.onOverlayState.useSubscription(undefined, {
+		onData: (next) => utils.lyrics.overlayState.setData(undefined, next),
+	});
+
+	return {
+		snapshot: snapshot ?? EMPTY_LYRICS_OVERLAY_SNAPSHOT,
+		clock: clock ?? null,
+		locked: state?.locked ?? false,
+	};
+}
+
+/** Local playback time extrapolated from the last clock packet; only animates while playing. */
+function usePlaybackTime(clock: LyricsOverlayClock | null): number {
+	const [timeMs, setTimeMs] = useState(() => Math.round(resolveLyricsOverlayTimeMs(clock, Date.now())));
+	useEffect(() => {
+		let raf = 0;
+		const frame = () => {
+			setTimeMs(Math.round(resolveLyricsOverlayTimeMs(clock, Date.now())));
+			if (clock?.playing) raf = requestAnimationFrame(frame);
+		};
+		frame();
+		return () => cancelAnimationFrame(raf);
+	}, [clock]);
+	return timeMs;
+}
+
+function lineProgress(line: LyricsOverlayLine, timeMs: number): number {
+	if (!(line.durationMs > 0) || !Number.isFinite(line.durationMs)) return 0;
+	return Math.min(1, Math.max(0, (timeMs - line.timeMs) / line.durationMs));
+}
+
+interface WordsProps {
+	words: LyricsOverlayWord[];
+	activeWord: number;
+	/** Playback time for the sweep; null = step only. */
+	fillTimeMs: number | null;
+}
+
+const Words = memo(function Words({ words, activeWord, fillTimeMs }: WordsProps) {
+	return (
+		<>
+			{words.map((word, w) => {
+				const cls = w < activeWord ? "ytmd-overlay-word is-sung" : w === activeWord ? "ytmd-overlay-word is-current" : "ytmd-overlay-word";
+				const style =
+					fillTimeMs != null
+						? ({ "--ytmd-word-progress": `${wordProgress(word, fillTimeMs) * 100}%` } as CSSProperties)
+						: undefined;
+				return (
+					<span key={`${word.timeMs}-${w}`} className={cls} style={style}>
+						{word.text}
+					</span>
+				);
+			})}
+		</>
+	);
+});
+
+interface LineProps {
+	line: LyricsOverlayLine;
+	isActive: boolean;
+	lineStyle: LyricsOverlaySettings["lineStyle"];
+	timeMs: number;
+}
+
+const Line = memo(function Line({ line, isActive, lineStyle, timeMs }: LineProps) {
+	const words = line.words?.length ? line.words : null;
+	const activeWord = isActive && words ? activeWordIndex(words, timeMs) : -1;
+	const sweeping = isActive && !!words && lineStyle === "fill";
+	// The bar is the only line-only indicator: constant rate across the line's duration.
+	const barProgress = isActive && !words && lineStyle === "bar" ? lineProgress(line, timeMs) : null;
+	const style = barProgress != null ? ({ "--ytmd-line-progress": String(barProgress) } as CSSProperties) : undefined;
+	const text = line.text || "♪";
+
+	return (
+		<div
+			className={cn("ytmd-overlay-line", `style-${lineStyle}`, isActive ? "is-active" : "is-next", words && "has-words")}
+			style={style}
+		>
+			<span className="ytmd-overlay-base">
+				{words ? <Words words={words} activeWord={activeWord} fillTimeMs={null} /> : text}
+			</span>
+			{sweeping && words ? (
+				<span className="ytmd-overlay-fill" aria-hidden="true">
+					<Words words={words} activeWord={activeWord} fillTimeMs={timeMs} />
+				</span>
+			) : null}
+		</div>
+	);
+});
+
+function trackLabel(snap: LyricsOverlaySnapshot): string {
+	const artists = snap.artists.filter(Boolean).join(", ");
+	if (snap.title && artists) return `${snap.title} · ${artists}`;
+	return snap.title || artists;
+}
+
+function statusLine(snap: LyricsOverlaySnapshot, lyricsEnabled: boolean, locked: boolean): string | null {
+	if (!lyricsEnabled || snap.status === "disabled") return locked ? null : "Enable lyrics in Settings → Player → Lyrics";
+	switch (snap.status) {
+		case "loading":
+			return locked ? null : "Loading lyrics…";
+		case "ready":
+			return null;
+		case "plain":
+		case "empty":
+			return trackLabel(snap) || (locked ? null : "No synced lyrics for this song");
+		default:
+			return locked ? null : "Play a song to see lyrics here";
+	}
+}
+
+function LyricsOverlayPage() {
+	const { overlay, lyricsEnabled } = useOverlaySettings();
+	const { snapshot, clock, locked } = useOverlayFeed();
+	const timeMs = usePlaybackTime(clock);
+	const { mutate: setLocked } = trpc.lyrics.setOverlayLocked.useMutation();
+	const { mutate: setEnabled } = trpc.lyrics.setOverlayEnabled.useMutation();
+	const { mutate: openSettings } = trpc.app.openSettings.useMutation();
+
+	useEffect(() => {
+		document.documentElement.classList.add("translucent");
+		document.title = "Lyrics";
+		return () => document.documentElement.classList.remove("translucent");
+	}, []);
+
+	const lines = lyricsEnabled && snapshot.status === "ready" ? snapshot.lines : null;
+	const activeIdx = lines ? primaryActiveLineIndex(lines, timeMs) : -1;
+	const active = lines && activeIdx >= 0 ? lines[activeIdx] : null;
+	const next = lines && activeIdx + 1 < lines.length ? lines[activeIdx + 1] : null;
+	// Before the first cue, preview the first line as "next" so the window is not blank.
+	const upcoming = active ? next : (lines?.[0] ?? null);
+	const status = statusLine(snapshot, lyricsEnabled, locked);
+
+	const rootStyle = {
+		"--ytmd-ov-text": overlay.textColor,
+		"--ytmd-ov-accent": overlay.accentColor,
+		"--ytmd-ov-next": overlay.nextLineColor,
+		"--ytmd-ov-font-size": `${overlay.fontSize}px`,
+		"--ytmd-ov-outline-color": overlay.outlineColor,
+		"--ytmd-ov-outline-width": `${overlay.outlineWidth}px`,
+		"--ytmd-ov-shadow-color": overlay.shadowColor,
+		"--ytmd-ov-bar-bg": overlay.barBackground,
+		"--ytmd-ov-bar-fg": overlay.barProgressColor,
+	} as CSSProperties;
+
+	return (
+		<div className={cn(
+				"ytmd-overlay",
+				locked ? "is-locked" : "is-unlocked",
+				!overlay.textOutline && "no-outline",
+				!overlay.textShadow && "no-shadow",
+			)} style={rootStyle}>
+			{!locked ? (
+				<div className="ytmd-overlay-bar">
+					<GripHorizontalIcon className="ytmd-overlay-grip size-3.5" />
+					<span className="ytmd-overlay-hint">Drag to move · pull the edges to resize · lock when done</span>
+					<button type="button" onClick={() => openSettings()} title="Lyrics settings">
+						<Settings2Icon className="size-3" />
+					</button>
+					<button type="button" className="is-primary" onClick={() => setLocked(true)} title="Lock: click-through and always on top">
+						<LockIcon className="size-3" />
+						Lock
+					</button>
+					<button type="button" onClick={() => setEnabled(false)} title="Hide desktop lyrics">
+						<XIcon className="size-3" />
+					</button>
+				</div>
+			) : null}
+			<div className={cn("ytmd-overlay-lines", `align-${overlay.align}`)}>
+				{active ? <Line line={active} isActive lineStyle={overlay.lineStyle} timeMs={timeMs} /> : null}
+				{overlay.showNextLine && upcoming ? <Line line={upcoming} isActive={false} lineStyle={overlay.lineStyle} timeMs={timeMs} /> : null}
+				{!active && !upcoming && status ? (
+					<div className="ytmd-overlay-line is-status">
+						<span className="ytmd-overlay-base">{status}</span>
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/apps/ytmdesktop2/src/renderer/src/styles/lyrics-overlay.css
+++ b/apps/ytmdesktop2/src/renderer/src/styles/lyrics-overlay.css
@@ -1,0 +1,237 @@
+/* Desktop lyrics overlay (`/lyrics-overlay`). The BrowserWindow is transparent, so nothing here may
+ * paint a full-window background: the page ground must stay see-through. */
+html.translucent #app {
+	background: transparent;
+	overflow: hidden;
+}
+
+.ytmd-overlay {
+	--ytmd-ov-text: #ffffff;
+	--ytmd-ov-accent: #5ab4ff;
+	--ytmd-ov-next: #ffffffb8;
+	--ytmd-ov-font-size: 30px;
+	--ytmd-ov-outline-color: #000000cc;
+	--ytmd-ov-outline-width: 2px;
+	--ytmd-ov-shadow-color: #00000099;
+	--ytmd-ov-bar-bg: #00000047;
+	--ytmd-ov-bar-fg: #5ab4ff73;
+	/* Toggles: the classes below zero these out. */
+	--ytmd-ov-stroke: var(--ytmd-ov-outline-width) var(--ytmd-ov-outline-color);
+	--ytmd-ov-shadow: 0 2px 6px var(--ytmd-ov-shadow-color);
+	/* Unsung part of the active line: text colour pulled toward the outline colour, so the sweep /
+	 * word step is visible even when text and accent are both white (opacity would also fade the
+	 * outline, which must stay crisp on light desktops). */
+	--ytmd-ov-dim: color-mix(in srgb, var(--ytmd-ov-text) 45%, var(--ytmd-ov-outline-color));
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	width: 100vw;
+	height: 100vh;
+	padding: 6px 14px;
+	overflow: hidden;
+	font-family: "YouTube Sans", "Noto Sans CJK TC", "Microsoft JhengHei", Roboto, Arial, sans-serif;
+	font-weight: 700;
+	line-height: 1.25;
+	user-select: none;
+	-webkit-user-select: none;
+	color: var(--ytmd-ov-text);
+}
+
+.ytmd-overlay.no-outline {
+	--ytmd-ov-stroke: 0 transparent;
+}
+
+.ytmd-overlay.no-shadow {
+	--ytmd-ov-shadow: none;
+}
+
+/* Unlocked: dashed outline shows the window bounds while it is movable / resizable. */
+.ytmd-overlay.is-unlocked {
+	border-radius: 10px;
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+	background: rgba(0, 0, 0, 0.18);
+}
+
+.ytmd-overlay-bar {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: 0 0 auto;
+	height: 26px;
+	margin: -2px -8px 4px;
+	padding: 0 6px;
+	border-radius: 8px;
+	font-size: 11px;
+	font-weight: 500;
+	color: rgba(255, 255, 255, 0.85);
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+	background: rgba(0, 0, 0, 0.45);
+	-webkit-app-region: drag;
+}
+
+.ytmd-overlay-bar .ytmd-overlay-grip {
+	opacity: 0.7;
+}
+
+.ytmd-overlay-bar .ytmd-overlay-hint {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.ytmd-overlay-bar button {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	height: 20px;
+	padding: 0 7px;
+	border: 0;
+	border-radius: 6px;
+	background: rgba(255, 255, 255, 0.12);
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+	-webkit-app-region: no-drag;
+}
+
+.ytmd-overlay-bar button:hover {
+	background: rgba(255, 255, 255, 0.24);
+}
+
+.ytmd-overlay-bar button.is-primary {
+	background: var(--ytmd-ov-accent);
+	color: #000;
+}
+
+.ytmd-overlay-lines {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 0.18em;
+	flex: 1 1 auto;
+	min-height: 0;
+	font-size: var(--ytmd-ov-font-size);
+}
+
+.ytmd-overlay-lines.align-left {
+	align-items: flex-start;
+	text-align: left;
+}
+
+.ytmd-overlay-lines.align-center {
+	align-items: center;
+	text-align: center;
+}
+
+.ytmd-overlay-lines.align-right {
+	align-items: flex-end;
+	text-align: right;
+}
+
+.ytmd-overlay-line {
+	position: relative;
+	display: inline-block;
+	max-width: 100%;
+	padding: 0.08em 0.4em;
+	border-radius: 0.35em;
+	overflow-wrap: break-word;
+	white-space: pre-wrap;
+	transition: opacity 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ytmd-overlay-line.is-next {
+	font-size: 0.72em;
+	font-weight: 600;
+}
+
+.ytmd-overlay-line.is-status {
+	font-size: 0.6em;
+	font-weight: 500;
+}
+
+/* Next-line colour carries its own alpha, so no extra opacity (it would compound). */
+.ytmd-overlay-line.is-next .ytmd-overlay-base,
+.ytmd-overlay-line.is-status .ytmd-overlay-base {
+	color: var(--ytmd-ov-next);
+	-webkit-text-fill-color: var(--ytmd-ov-next);
+}
+
+/* Base layer: plain text carries the outline (stroke painted under the fill) and the shadow. */
+.ytmd-overlay-line .ytmd-overlay-base {
+	position: relative;
+	z-index: 1;
+	color: var(--ytmd-ov-text);
+	-webkit-text-fill-color: var(--ytmd-ov-text);
+	-webkit-text-stroke: var(--ytmd-ov-stroke);
+	paint-order: stroke fill;
+	text-shadow: var(--ytmd-ov-shadow);
+}
+
+/* Line-only cues in Highlight mode — and in Text fill mode, which has nothing to sweep without
+ * word cues — colour the whole active line with the accent. */
+.ytmd-overlay-line.is-active.style-highlight:not(.has-words) .ytmd-overlay-base,
+.ytmd-overlay-line.is-active.style-fill:not(.has-words) .ytmd-overlay-base {
+	color: var(--ytmd-ov-accent);
+	-webkit-text-fill-color: var(--ytmd-ov-accent);
+}
+
+/* Bar style (line-only cues): translucent pill whose accent portion advances with playback. */
+.ytmd-overlay-line.is-active.style-bar {
+	background-image: linear-gradient(
+		to right,
+		var(--ytmd-ov-bar-fg) 0%,
+		var(--ytmd-ov-bar-fg) calc(var(--ytmd-line-progress, 0) * 100%),
+		var(--ytmd-ov-bar-bg) calc(var(--ytmd-line-progress, 0) * 100%),
+		var(--ytmd-ov-bar-bg) 100%
+	);
+}
+
+/* Fill style (word cues): a second copy of the words sits exactly over the base layer and paints
+ * only the sung part in accent (unsung part is transparent so the base shows through). Keeping the
+ * shadow on the base layer avoids the "shadow on top of background-clip:text" artefact. */
+.ytmd-overlay-line .ytmd-overlay-fill {
+	position: absolute;
+	inset: 0;
+	z-index: 2;
+	padding: inherit;
+	box-sizing: border-box;
+	pointer-events: none;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+	-webkit-text-stroke: 0 transparent;
+	text-shadow: none;
+}
+
+.ytmd-overlay-fill .ytmd-overlay-word {
+	background-image: linear-gradient(
+		to right,
+		var(--ytmd-ov-accent) var(--ytmd-word-progress, 0%),
+		transparent var(--ytmd-word-progress, 0%)
+	);
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+}
+
+/* Word-synced active line: the base layer shows every word dimmed. Text fill paints the sung part
+ * in accent on the sweep layer above; Highlight / Progress bar step the base words themselves. */
+.ytmd-overlay-line.is-active.has-words .ytmd-overlay-base .ytmd-overlay-word {
+	color: var(--ytmd-ov-dim);
+	-webkit-text-fill-color: var(--ytmd-ov-dim);
+	transition: color 160ms ease;
+}
+
+.ytmd-overlay-line.is-active:not(.style-fill) .ytmd-overlay-base .ytmd-overlay-word.is-sung,
+.ytmd-overlay-line.is-active:not(.style-fill) .ytmd-overlay-base .ytmd-overlay-word.is-current {
+	color: var(--ytmd-ov-accent);
+	-webkit-text-fill-color: var(--ytmd-ov-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.ytmd-overlay-line {
+		transition: none;
+	}
+}

--- a/apps/ytmdesktop2/src/shared/lyrics/overlay.test.ts
+++ b/apps/ytmdesktop2/src/shared/lyrics/overlay.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_LYRICS_OVERLAY_SETTINGS,
+	joinHexColor,
+	readLyricsOverlaySettings,
+	resolveLyricsOverlayTimeMs,
+	splitHexColor,
+} from "./overlay";
+
+describe("readLyricsOverlaySettings", () => {
+	it("returns defaults for missing / garbage input", () => {
+		expect(readLyricsOverlaySettings(undefined)).toEqual(DEFAULT_LYRICS_OVERLAY_SETTINGS);
+		expect(readLyricsOverlaySettings("nope")).toEqual(DEFAULT_LYRICS_OVERLAY_SETTINGS);
+		expect(readLyricsOverlaySettings({ enabled: "yes", lineStyle: "rainbow", align: "middle" })).toEqual(DEFAULT_LYRICS_OVERLAY_SETTINGS);
+	});
+
+	it("clamps the font size and keeps it integral", () => {
+		expect(readLyricsOverlaySettings({ fontSize: 3 }).fontSize).toBe(14);
+		expect(readLyricsOverlaySettings({ fontSize: 500 }).fontSize).toBe(72);
+		expect(readLyricsOverlaySettings({ fontSize: "24.6" }).fontSize).toBe(25);
+		expect(readLyricsOverlaySettings({ fontSize: NaN }).fontSize).toBe(DEFAULT_LYRICS_OVERLAY_SETTINGS.fontSize);
+	});
+
+	it("only accepts safe colour literals (they land in a style attribute)", () => {
+		expect(readLyricsOverlaySettings({ textColor: "#abc" }).textColor).toBe("#abc");
+		expect(readLyricsOverlaySettings({ accentColor: "rgba(10, 20, 30, 0.5)" }).accentColor).toBe("rgba(10, 20, 30, 0.5)");
+		expect(readLyricsOverlaySettings({ textColor: "url(javascript:alert(1))" }).textColor).toBe(DEFAULT_LYRICS_OVERLAY_SETTINGS.textColor);
+		expect(readLyricsOverlaySettings({ textColor: "red; background: url(x)" }).textColor).toBe(DEFAULT_LYRICS_OVERLAY_SETTINGS.textColor);
+	});
+
+	it("passes valid overrides through", () => {
+		expect(readLyricsOverlaySettings({ enabled: true, locked: true, lineStyle: "bar", align: "left", showNextLine: false })).toMatchObject({
+			enabled: true,
+			locked: true,
+			lineStyle: "bar",
+			align: "left",
+			showNextLine: false,
+		});
+	});
+});
+
+describe("outline width", () => {
+	it("clamps to the allowed range in half-pixel steps", () => {
+		expect(readLyricsOverlaySettings({ outlineWidth: 0 }).outlineWidth).toBe(0.5);
+		expect(readLyricsOverlaySettings({ outlineWidth: 9 }).outlineWidth).toBe(6);
+		expect(readLyricsOverlaySettings({ outlineWidth: 1.3 }).outlineWidth).toBe(1.5);
+		expect(readLyricsOverlaySettings({ outlineWidth: "abc" }).outlineWidth).toBe(DEFAULT_LYRICS_OVERLAY_SETTINGS.outlineWidth);
+	});
+});
+
+describe("splitHexColor / joinHexColor", () => {
+	it("round-trips #rrggbbaa and expands short forms", () => {
+		expect(splitHexColor("#ffffffb8")).toEqual({ hex: "#ffffff", alpha: 0xb8 / 255 });
+		expect(splitHexColor("#5AB4FF")).toEqual({ hex: "#5ab4ff", alpha: 1 });
+		expect(splitHexColor("#08f")).toEqual({ hex: "#0088ff", alpha: 1 });
+		expect(splitHexColor("#08f8")).toEqual({ hex: "#0088ff", alpha: 0x88 / 255 });
+		expect(splitHexColor("garbage")).toEqual({ hex: "#000000", alpha: 1 });
+	});
+
+	it("joins back, dropping the alpha byte when opaque and clamping otherwise", () => {
+		expect(joinHexColor("#5ab4ff", 1)).toBe("#5ab4ff");
+		expect(joinHexColor("#5ab4ff", 0.45)).toBe("#5ab4ff73");
+		expect(joinHexColor("#5ab4ff", 0)).toBe("#5ab4ff00");
+		expect(joinHexColor("#5ab4ff", 7)).toBe("#5ab4ff");
+		expect(joinHexColor("#5ab4ffaa", NaN)).toBe("#5ab4ff");
+		const { hex, alpha } = splitHexColor("#00000047");
+		expect(joinHexColor(hex, alpha)).toBe("#00000047");
+	});
+});
+
+describe("resolveLyricsOverlayTimeMs", () => {
+	it("extrapolates while playing and freezes while paused", () => {
+		expect(resolveLyricsOverlayTimeMs({ timeMs: 10_000, playing: true, at: 1_000 }, 1_250)).toBe(10_250);
+		expect(resolveLyricsOverlayTimeMs({ timeMs: 10_000, playing: false, at: 1_000 }, 5_000)).toBe(10_000);
+	});
+
+	it("never runs backwards on clock skew and tolerates a missing packet", () => {
+		expect(resolveLyricsOverlayTimeMs({ timeMs: 10_000, playing: true, at: 2_000 }, 1_000)).toBe(10_000);
+		expect(resolveLyricsOverlayTimeMs(null, 1_000)).toBe(0);
+	});
+});

--- a/apps/ytmdesktop2/src/shared/lyrics/overlay.ts
+++ b/apps/ytmdesktop2/src/shared/lyrics/overlay.ts
@@ -1,0 +1,211 @@
+/**
+ * Desktop lyrics overlay contract shared by the youtube preload plugin (publisher), the main
+ * process (window owner / relay) and the `/lyrics-overlay` renderer route (consumer).
+ */
+
+export type LyricsOverlayLineStyle = "highlight" | "bar" | "fill";
+export type LyricsOverlayAlign = "left" | "center" | "right";
+
+export interface LyricsOverlaySettings {
+	/** Overlay window open. */
+	enabled: boolean;
+	/** Click-through + unfocusable; position and size frozen. */
+	locked: boolean;
+	lineStyle: LyricsOverlayLineStyle;
+	/** Active line font size (px). */
+	fontSize: number;
+	/** Unsung / inactive text colour (CSS colour). */
+	textColor: string;
+	/** Sung / active colour: fill sweep, stepped words, and the whole line in Highlight mode. */
+	accentColor: string;
+	/** Draw the upcoming line under the active one. */
+	showNextLine: boolean;
+	/** Next-line colour; alpha doubles as its opacity (#rrggbbaa). */
+	nextLineColor: string;
+	/** Crisp stroke around glyphs so text stays readable on light desktops. */
+	textOutline: boolean;
+	outlineColor: string;
+	/** Stroke width (px). */
+	outlineWidth: number;
+	/** Soft drop shadow under the glyphs. */
+	textShadow: boolean;
+	shadowColor: string;
+	/** Progress-bar mode: unplayed part of the pill behind the active line. */
+	barBackground: string;
+	/** Progress-bar mode: played part of the pill. */
+	barProgressColor: string;
+	align: LyricsOverlayAlign;
+}
+
+export const DEFAULT_LYRICS_OVERLAY_SETTINGS: LyricsOverlaySettings = {
+	enabled: false,
+	locked: false,
+	lineStyle: "fill",
+	fontSize: 30,
+	textColor: "#ffffff",
+	accentColor: "#5ab4ff",
+	showNextLine: true,
+	nextLineColor: "#ffffffb8",
+	textOutline: true,
+	outlineColor: "#000000cc",
+	outlineWidth: 2,
+	textShadow: true,
+	shadowColor: "#00000099",
+	barBackground: "#00000047",
+	barProgressColor: "#5ab4ff73",
+	align: "center",
+};
+
+export const LYRICS_OVERLAY_OUTLINE_WIDTH = { min: 0.5, max: 6 } as const;
+
+export const LYRICS_OVERLAY_FONT_SIZE = { min: 14, max: 72 } as const;
+
+/** Default overlay window size (DIP). Height fits two lines at the default font size. */
+export const LYRICS_OVERLAY_DEFAULT_SIZE = { width: 900, height: 150 } as const;
+export const LYRICS_OVERLAY_MIN_SIZE = { width: 320, height: 80 } as const;
+
+function readBool(value: unknown, fallback: boolean): boolean {
+	return typeof value === "boolean" ? value : fallback;
+}
+
+function readColor(value: unknown, fallback: string): string {
+	if (typeof value !== "string") return fallback;
+	const v = value.trim();
+	// Hex / rgb(a) / hsl(a) only — this string lands in a style attribute of a transparent window.
+	if (/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(v)) return v;
+	if (/^(?:rgb|hsl)a?\([\d.,%\s/]+\)$/i.test(v)) return v;
+	return fallback;
+}
+
+export function readLyricsOverlayLineStyle(value: unknown): LyricsOverlayLineStyle {
+	return value === "highlight" || value === "bar" || value === "fill" ? value : DEFAULT_LYRICS_OVERLAY_SETTINGS.lineStyle;
+}
+
+export function readLyricsOverlayFontSize(value: unknown): number {
+	const n = typeof value === "number" ? value : Number(value);
+	if (!Number.isFinite(n)) return DEFAULT_LYRICS_OVERLAY_SETTINGS.fontSize;
+	return Math.round(Math.min(LYRICS_OVERLAY_FONT_SIZE.max, Math.max(LYRICS_OVERLAY_FONT_SIZE.min, n)));
+}
+
+function readOutlineWidth(value: unknown): number {
+	const n = typeof value === "number" ? value : Number(value);
+	if (!Number.isFinite(n)) return DEFAULT_LYRICS_OVERLAY_SETTINGS.outlineWidth;
+	return Math.round(Math.min(LYRICS_OVERLAY_OUTLINE_WIDTH.max, Math.max(LYRICS_OVERLAY_OUTLINE_WIDTH.min, n)) * 2) / 2;
+}
+
+/** `#rrggbb[aa]` / `#rgb[a]` → 6-digit hex + 0..1 alpha (for a colour picker + opacity slider pair). */
+export function splitHexColor(value: string): { hex: string; alpha: number } {
+	const m = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.exec(value.trim());
+	if (!m) return { hex: "#000000", alpha: 1 };
+	let digits = m[1].toLowerCase();
+	if (digits.length <= 4) digits = [...digits].map((c) => c + c).join("");
+	const hex = `#${digits.slice(0, 6)}`;
+	const alpha = digits.length === 8 ? Number.parseInt(digits.slice(6, 8), 16) / 255 : 1;
+	return { hex, alpha };
+}
+
+/** Inverse of `splitHexColor`; drops the alpha digits when fully opaque. */
+export function joinHexColor(hex: string, alpha: number): string {
+	const { hex: base } = splitHexColor(hex);
+	const a = Math.round(Math.min(1, Math.max(0, Number.isFinite(alpha) ? alpha : 1)) * 255);
+	if (a >= 255) return base;
+	return `${base}${a.toString(16).padStart(2, "0")}`;
+}
+
+/** Normalize the raw `lyrics.overlay` settings object (any shape) into a full settings record. */
+export function readLyricsOverlaySettings(raw: unknown): LyricsOverlaySettings {
+	const s = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+	const d = DEFAULT_LYRICS_OVERLAY_SETTINGS;
+	return {
+		enabled: readBool(s.enabled, d.enabled),
+		locked: readBool(s.locked, d.locked),
+		lineStyle: readLyricsOverlayLineStyle(s.lineStyle),
+		fontSize: readLyricsOverlayFontSize(s.fontSize),
+		textColor: readColor(s.textColor, d.textColor),
+		accentColor: readColor(s.accentColor, d.accentColor),
+		showNextLine: readBool(s.showNextLine, d.showNextLine),
+		nextLineColor: readColor(s.nextLineColor, d.nextLineColor),
+		textOutline: readBool(s.textOutline, d.textOutline),
+		outlineColor: readColor(s.outlineColor, d.outlineColor),
+		outlineWidth: readOutlineWidth(s.outlineWidth),
+		textShadow: readBool(s.textShadow, d.textShadow),
+		shadowColor: readColor(s.shadowColor, d.shadowColor),
+		barBackground: readColor(s.barBackground, d.barBackground),
+		barProgressColor: readColor(s.barProgressColor, d.barProgressColor),
+		align: s.align === "left" || s.align === "right" ? s.align : "center",
+	};
+}
+
+/** Structural twins of the lyrics plugin `LyricWord` / `LyricLine` (kept here so main/renderer never import the plugin). */
+export interface LyricsOverlayWord {
+	timeMs: number;
+	text: string;
+	durationMs: number;
+}
+
+export interface LyricsOverlayLine {
+	timeMs: number;
+	text: string;
+	durationMs: number;
+	parts?: string[];
+	words?: LyricsOverlayWord[];
+}
+
+export type LyricsOverlaySnapshotStatus = "idle" | "loading" | "ready" | "plain" | "empty" | "disabled";
+
+/** What the overlay draws for the current track. Sent once per change, not per frame. */
+export interface LyricsOverlaySnapshot {
+	status: LyricsOverlaySnapshotStatus;
+	videoId: string | null;
+	title: string;
+	artists: string[];
+	/** Timed lines when `status === "ready"`. */
+	lines: LyricsOverlayLine[] | null;
+	hasWordSync: boolean;
+}
+
+export const EMPTY_LYRICS_OVERLAY_SNAPSHOT: LyricsOverlaySnapshot = {
+	status: "idle",
+	videoId: null,
+	title: "",
+	artists: [],
+	lines: null,
+	hasWordSync: false,
+};
+
+/**
+ * Playback clock sync packet. The overlay extrapolates from `timeMs` using its own clock while
+ * `playing`, so the publisher only needs to resend on play/pause/seek and a slow heartbeat.
+ */
+export interface LyricsOverlayClock {
+	/** Player time at `at` (ms, display lead already applied). */
+	timeMs: number;
+	playing: boolean;
+	/** `Date.now()` on the publisher when `timeMs` was read. */
+	at: number;
+}
+
+export function resolveLyricsOverlayTimeMs(clock: LyricsOverlayClock | null | undefined, nowMs: number): number {
+	if (!clock) return 0;
+	if (!clock.playing) return clock.timeMs;
+	const elapsed = nowMs - clock.at;
+	return clock.timeMs + (elapsed > 0 ? elapsed : 0);
+}
+
+export interface LyricsOverlayWindowState {
+	open: boolean;
+	locked: boolean;
+}
+
+/** Preload plugin → main (ipcRenderer.send). */
+export const LYRICS_OVERLAY_IPC = {
+	snapshot: "lyrics:overlay-snapshot",
+	clock: "lyrics:overlay-clock",
+} as const;
+
+/** Main bus → overlay window tRPC subscriptions (`fromIpcEvent`). */
+export const LYRICS_OVERLAY_EVENTS = {
+	snapshot: "lyrics.overlay.snapshot",
+	clock: "lyrics.overlay.clock",
+	state: "lyrics.overlay.state",
+} as const;


### PR DESCRIPTION
> **Stacked on #254** — please review that first. This PR is only the last commit (`6b820b7`); the diff will shrink to just that commit once #254 merges.

## Summary

QQ Music–style floating lyrics: a transparent, frameless, always-on-top window that shows the current line (plus the next one) over any app. Drag it anywhere, resize from the edges, then **lock** it — locked, it's click-through and never takes focus, so mouse and keyboard go straight to whatever is underneath.

## What's included

- **Overlay window** (`/lyrics-overlay`): current + next line; same three highlight styles as the in-app Lyrics tab — **Text fill** (per-word sweep), **Progress bar** (background advances, line-only songs), **Highlight** (word step / whole line). Fallbacks match the in-app behaviour (Text fill → Highlight on line-only songs).
- **Lock mode**: `setIgnoreMouseEvents` + `setFocusable(false)` + frozen bounds. Alt+F4 / the window's ✕ just flips the setting off. Position/size persist and restore on launch.
- **Controls**: Settings → Player → Lyrics → *Desktop lyrics* card, and a tray *Desktop Lyrics* submenu (Show / Lock / Reset position).
- **Customisation**: font size, text / accent / next-line colour (+ opacity), progress-bar background & fill colours, outline colour + width (real `text-stroke`), shadow colour, alignment. New `SettingsColor` control = colour picker + opacity slider stored as one `#rrggbbaa`.
- Unsung words in the active line are dimmed toward the outline colour, so the sweep/step stays visible even if text and accent colours are both white.


<img width="2557" height="1432" alt="image" src="https://github.com/user-attachments/assets/ae488ae7-9585-420f-9ebe-aa5fa88118d6" />


<img width="977" height="1057" alt="image" src="https://github.com/user-attachments/assets/f13d01d7-d154-4f45-b446-69db987dce76" />

<img width="1397" height="1136" alt="image" src="https://github.com/user-attachments/assets/faa33d84-4478-4e0e-8109-73ef975b76ef" />


<img width="1268" height="146" alt="image" src="https://github.com/user-attachments/assets/a60c5e6d-6f51-440d-a9ad-bb6700c65201" />


## How it works

- The youtube lyrics plugin publishes a **snapshot** once per track change and a **clock packet** only on play/pause, seek drift > 90 ms, or a 1.5 s heartbeat. The overlay extrapolates time locally at 60 fps — no per-frame IPC.
- The main `lyrics` provider relays both over `serverMain` → tRPC subscriptions (`lyrics.onOverlaySnapshot/Clock/State`) and owns the window lifecycle.
- The plugin's page clock now also reports `playing` (`getPlayerState() === 1`) and keeps running while the overlay is open, even if the Lyrics tab isn't selected.
- `createAppWindow` gained `transparent` / `resizable` / `extraOptions`.
- A settings migration backfills `lyrics.overlay.*` defaults for existing stores.

## Settings added

| Key | Default |
| --- | --- |
| `lyrics.overlay.enabled` / `locked` | `false` / `false` |
| `lyrics.overlay.lineStyle` | `"fill"` |
| `lyrics.overlay.fontSize` | `30` |
| `lyrics.overlay.textColor` / `accentColor` | `#ffffff` / `#5ab4ff` |
| `lyrics.overlay.showNextLine` / `nextLineColor` | `true` / `#ffffffb8` |
| `lyrics.overlay.textOutline` / `outlineColor` / `outlineWidth` | `true` / `#000000cc` / `2` |
| `lyrics.overlay.textShadow` / `shadowColor` | `true` / `#00000099` |
| `lyrics.overlay.barBackground` / `barProgressColor` | `#00000047` / `#5ab4ff73` |
| `lyrics.overlay.align` | `"center"` |

## Test plan

- [x] `pnpm typecheck` (node + web), `biome check` clean
- [x] `pnpm test` — 137 passing (15 new: settings normalisation, hex colour split/join, clock extrapolation, publisher dedupe / drift / heartbeat)
- [x] Windows 11: open / lock / unlock / drag / resize; all three styles on word-synced (Better Lyrics) and line-only (LRCLib) songs
- [x] Restart with overlay enabled + locked → restored at the saved position, still click-through
- [x] Alt+F4 on the overlay → setting turns off, tray menu and Settings card update
- [x] Colour / outline / shadow changes apply live without reopening the window

## Notes

- Windows only for now; macOS/Linux will need the panel-type / `setVisibleOnAllWorkspaces` tuning already used by the tray view.
- Exclusive-fullscreen games can't be covered by any topmost window; borderless works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
